### PR TITLE
Source maps

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -389,6 +389,7 @@ Return.prototype.toString = function () {
 
 function Root (statements) {
   this.statements = statements
+  this.sourceMap  = null
 }
 inherits(Root, Node)
 Root.prototype.print = function (includeTypes) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,6 +1,7 @@
-var stderr = process.stderr,
-    fs     = require('fs'),
-    path   = require('path')
+var stderr                 = process.stderr,
+    fs                     = require('fs'),
+    path                   = require('path'),
+    inlineSourceMapComment = require('inline-source-map-comment')
 
 var TypeSystem  = require('./typesystem').TypeSystem,
     Parser      = require('./parser'),
@@ -10,6 +11,8 @@ var TypeSystem  = require('./typesystem').TypeSystem,
 var optimist = require('optimist')
 var argv = optimist
     .usage('Usage: hb [command] [options]')
+    .boolean('m')
+    .alias('m', 'map')
     // .demand(1)
     .argv
 
@@ -17,10 +20,12 @@ function showHelp () {
   var help = optimist.help().trim()
   help += "\n\n"
   help += "Commands:\n"
-  help += "  run [file]      Compile and run a file\n"
-  help += "  compile [file]  Compile a file to JavaScript; writes to STDOUT\n"
-  help += "  inspect [file]  Print the compiled AST of a file\n"
-  help += "  help            Show this help message\n"
+  help += "  run [file]                Compile and run a file\n"
+  help += "  compile [options] [file]  Compile a file to JavaScript; writes to STDOUT\n"
+  help += "  inspect [file]            Print the compiled AST of a file\n"
+  help += "  help                      Show this help message\n\n"
+  help += "Options:\n"
+  help += "  -m, --map                 Include source maps in output"
   console.error(help)
 }
 
@@ -82,6 +87,12 @@ var commands = {
     // Load the JavaScript compile target and print the compiled source
     require('./targets/javascript')
     process.stdout.write(tree.compile())
+    // Check whether we should also print the source-map
+    var includeMap = argv.m
+    if (includeMap) {
+      process.stdout.write(inlineSourceMapComment(tree.sourceMap))
+      process.stdout.write("\n")
+    }
   },
   run: function (args) {
     var file = fileFromArgs(args, 0),

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -82,7 +82,7 @@ elsecont   = "else" __ b:block { return b }
 
 whilectrl  = "while" _ c:innerstmt _ b:block { return p.parseWhile(c, b) }
 forctrl    = "for" _ i:innerstmt? _ ";" _ c:innerstmt? _ ";" _ a:innerstmt? _ b:block { return p.parseFor(i, c, a, b) }
-returnctrl = "return" e:(_ e:expr)? { return p.parseReturn(e ? e[1] : null) }
+returnctrl = pos "return" e:(_ e:expr)? { return p.parseReturn(e ? e[1] : null) }
 
 decl = letvardecl
      / classdecl

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -102,7 +102,7 @@ assgop = "="
 // Path assignment of existing variables and their indexes/properties
 path = n:name path:(indexer / property)* { return p.parsePath(n, path) }
 indexer = "[" _ expr _ "]"
-property = "." n:name { return p.parseProperty(n) }
+property = pos "." n:name { return p.parseProperty(n) }
 
 multistmt = pos "multi" whitespace n:name _ a:args _ r:ret? { return p.parseMutli(n, a, r) }
 

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -71,7 +71,7 @@ ctrl = ifctrl
      / forctrl
      / returnctrl
 
-ifctrl = "if" _ c:innerstmt __ b:block ei:(__ elseifcont)* e:(__ elsecont)? {
+ifctrl = pos "if" _ c:innerstmt __ b:block ei:(__ elseifcont)* e:(__ elsecont)? {
   ei = ei.map(function (pair) { return pair[1] })
   e  = e ? e[1] : null
   return p.parseIf(c, b, ei, e)

--- a/lib/parser-extension.js
+++ b/lib/parser-extension.js
@@ -119,7 +119,9 @@ module.exports = function (p) {
   }
 
   p.parseReturn = function (expr) {
-    return new AST.Return(expr)
+    var ret = new AST.Return(expr)
+    ret.setParsePosition(this)
+    return ret
   }
 
   p.parseCall = function (expr) {

--- a/lib/parser-extension.js
+++ b/lib/parser-extension.js
@@ -40,7 +40,9 @@ module.exports = function (p) {
   }
 
   p.parseIf = function (cond, block, elseIfs, elseBlock) {
-    return new AST.If(cond, block, elseIfs, elseBlock)
+    var i = new AST.If(cond, block, elseIfs, elseBlock)
+    i.setParsePosition(this)
+    return i
   }
 
   p.parseRoot = function (statements) {

--- a/lib/targets/javascript.js
+++ b/lib/targets/javascript.js
@@ -217,10 +217,10 @@ AST.Class.prototype.compile = function (context) {
       name  = this.name
   // Generate the simple class function
   // TODO: Multiple-dispatch initializers
-  var ret = "function "+name+" () {\n"
+  var ret = ["function "+name+" () {\n"]
 
   // Compile the initializer preamble
-  ret += this.compilePreamble(context)
+  ret = ret.concat(this.compilePreamble(context))
 
   // Compile the initializers
   var initializers = []
@@ -232,15 +232,15 @@ AST.Class.prototype.compile = function (context) {
   }
   // TODO: Add fast codepath for just one initializer
   if (initializers.length > 0) {
-    ret += this.compileInitializers(context, initializers)
+    ret.push(this.compileInitializers(context, initializers))
   }
 
-  ret += context.indent()+"}\n",
+  ret.push(context.indent()+"}\n")
   // Now add all the instance methods
   this.definition.statements.forEach(function (node) {
     if (!(node instanceof AST.Function)) { return }
     var methodName = node.name
-    ret += name+".prototype."+methodName+" = "+node.compile(context)
+    ret.push(name+".prototype."+methodName+" = ", node.compile(context))
   })
   return asSourceNode(this, ret)
 }
@@ -257,13 +257,13 @@ AST.Class.prototype.compilePreamble = function (context) {
     }
   })
   var ind = context.indent(2),
-      ret = ''
+      ret = []
   // By default we'll do the same handling for both properties' defaults
   var properties = letProperties.concat(varProperties)
   properties.forEach(function (prop) {
     // Skip properties with no default
     if (!prop.rvalue) { return }
-    ret += ind+'this.'+prop.lvalue.name+' = '+prop.rvalue.compile(context)+";\n"
+    ret.push(ind+'this.'+prop.lvalue.name+' = ', prop.rvalue.compile(context), ";\n")
   })
   return ret
 }

--- a/lib/targets/javascript.js
+++ b/lib/targets/javascript.js
@@ -151,9 +151,10 @@ Array.prototype.extend = function (other) {
 AST.Multi.prototype.compile = function (context) {
   // console.log(this)
   var args = this.args.map(function (arg) { return arg.name }),
+      joinedArgs = args.join(', '),// joinedArgs = interpose(args, ', ')
       name = this.name
   // Build function definition
-  var ret = 'function '+name+' ('+args.join(', ')+") {\n"
+  var ret = ['function ', name, ' (', joinedArgs, ") {\n"]
   context.incrementIndent()
 
   // Figure out the branches for the dispatcher
@@ -177,20 +178,20 @@ AST.Multi.prototype.compile = function (context) {
 
   // Build the dispatcher
   var ind = context.indent()
-  ret += ind+"switch (false) {\n"
+  ret.push(ind+"switch (false) {\n")
   cond.forEach(function (condFunction) {
     var childName = condFunction.childName
-    ret += ind+"case !("+condFunction.when.compile(context)+"):\n"
-    ret += context.indent(2)+"return "+childName+"("+args.join(", ")+");\n"
+    ret.push(ind+"case !(", condFunction.when.compile(context), "):\n")
+    ret.push(context.indent(2)+"return "+childName+"(", joinedArgs, ");\n")
   })
-  ret += ind+"default:\n"
+  ret.push(ind+"default:\n")
   var defInd = context.indent(2)
   if (def) {
-    ret += defInd+"return "+def.childName+"("+args.join(", ")+");\n"
+    ret.push(defInd+"return "+def.childName+"(", joinedArgs, ");\n")
   } else {
-    ret += defInd+"throw new Error('Fell through to default branch');\n"
+    ret.push(defInd+"throw new Error('Fell through to default branch');\n")
   }
-  ret += ind+"}\n"
+  ret.push(ind+"}\n")
 
   // Build all of the implementation functions
   ind = context.indent()
@@ -198,15 +199,15 @@ AST.Multi.prototype.compile = function (context) {
   this.type.functionNodes.forEach(function (functionNode) {
     var functionName = functionNode.childName,
         functionArgs = functionNode.args.map(function (arg) { return arg.name })
-    ret += ind+'function '+functionName+" ("+functionArgs.join(', ')+") {\n"
-    ret += functionNode.block.compile(context)
-    ret += ind+"}\n"
-    
+    ret.push(ind+'function '+functionName+" ("+functionArgs.join(', ')+") {\n")
+    ret.push(functionNode.block.compile(context))
+    ret.push(ind+"}\n")
+
     i += 1
   })
 
   context.decrementIndent()
-  ret += context.indent()+"}\n"
+  ret.push(context.indent()+"}\n")
   return asSourceNode(this, ret)
 }
 
@@ -217,7 +218,7 @@ AST.Class.prototype.compile = function (context) {
   // Generate the simple class function
   // TODO: Multiple-dispatch initializers
   var ret = "function "+name+" () {\n"
-  
+
   // Compile the initializer preamble
   ret += this.compilePreamble(context)
 
@@ -303,9 +304,9 @@ AST.Class.prototype.compileInitializers = function (context, initializers) {
       return arg.name
     }).join(', ')
     ret += ind+'function init'+branchLength+' ('+args+") {\n"
-    ret += branch.block.compile(context) 
+    ret += branch.block.compile(context)
     ret += ind+"}\n"
-  }) 
+  })
   context.decrementIndent()
   return ret
 }

--- a/lib/targets/javascript.js
+++ b/lib/targets/javascript.js
@@ -83,7 +83,7 @@ AST.Assignment.prototype.compile = function (context, opts) {
     var lvalue = this.lvalue.name
     if (this.rvalue !== false) {
       var rvalue = this.rvalue.compile(context)
-      ret = ['var ', lvalue, ' ', this.op, ' ', rvalue, term]
+      ret = ['var ', lvalue, ' '+this.op+' ', rvalue, term]
     } else {
       ret = ['var ', lvalue, term]
     }
@@ -95,7 +95,7 @@ AST.Assignment.prototype.compile = function (context, opts) {
       lvalue += item.compile(context)
     })
     var rvalue = this.rvalue.compile(context)
-    ret = [lvalue, ' ', this.op, ' ', rvalue, term]
+    ret = [lvalue, ' '+this.op+' ', rvalue, term]
   }
   return asSourceNode(this, ret)
 }
@@ -315,8 +315,10 @@ AST.New.prototype.compile = function (context) {
   var name = this.name,
       args = this.args.map(function (arg) {
         return arg.compile(context)
-      }).join(', ')
-  var ret = "(new "+name+"("+args+"))"
+      })
+  // Interpose commas between the args
+  args = interpose(args, ', ')
+  var ret = ["(new "+name+"(", args, "))"]
   return asSourceNode(this, ret)
 }
 

--- a/lib/targets/javascript.js
+++ b/lib/targets/javascript.js
@@ -83,9 +83,9 @@ AST.Assignment.prototype.compile = function (context, opts) {
     var lvalue = this.lvalue.name
     if (this.rvalue !== false) {
       var rvalue = this.rvalue.compile(context)
-      ret = 'var '+lvalue+' '+this.op+' '+rvalue+term
+      ret = ['var ', lvalue, ' ', this.op, ' ', rvalue, term]
     } else {
-      ret = 'var '+lvalue+term
+      ret = ['var ', lvalue, term]
     }
   } else {
     // TODO: Handle more complex path assignments
@@ -95,7 +95,7 @@ AST.Assignment.prototype.compile = function (context, opts) {
       lvalue += item.compile(context)
     })
     var rvalue = this.rvalue.compile(context)
-    ret = lvalue+' '+this.op+' '+rvalue+term
+    ret = [lvalue, ' ', this.op, ' ', rvalue, term]
   }
   return asSourceNode(this, ret)
 }
@@ -105,8 +105,8 @@ AST.Function.prototype.compile = function (context) {
   if (this.isChildOfMulti()) { return "" }
 
   var args = this.args.map(function (arg) { return arg.name }),
-      ret  = 'function ('+args.join(', ')+") {\n",
-      defs = ''
+      ret  = ['function (', args.join(', '), ") {\n"],
+      defs = []
   // Build assignments for any default arguments
   for (var i = args.length - 1; i >= 0; i--) {
     var arg  = this.args[i],
@@ -116,15 +116,15 @@ AST.Function.prototype.compile = function (context) {
       var value = def.compile(context),
           ind   = context.indent(2)
       // Prepend the default to the body
-      defs = ind+'if ('+name+' === undefined) { '+name+' = '+value+"; }\n"+defs
+      defs = [ind, 'if (', name, ' === undefined) { ', name, ' = ', value, "; }\n"].concat(defs)
     }
   }// for args
-  ret += defs
-  ret += this.block.compile(context)
-  ret += "}"
+  ret = ret.concat(defs)
+  ret.push(this.block.compile(context))
+  ret.push("}")
   // Name property indicates it's a function statement
   if (this.name) {
-    ret += "\n"
+    ret.push("\n")
   }
   return asSourceNode(this, ret)
 }
@@ -305,38 +305,49 @@ AST.Call.prototype.compile = function (context) {
   var args = this.args.map(function (arg) {
     return arg.compile(context)
   })
-  var ret = '('+args.join(', ')+')'
+  var ret = ['(']
+  var length = args.length, lastIndex = args.length - 1
+  for (var i = 0; i < length; i++) {
+    ret.push(args[i])
+    if (i !== lastIndex) {
+      ret.push(', ')
+    }
+  }
+  ret.push(')')
   return asSourceNode(this, ret)
 }
 
 AST.Property.prototype.compile = function (context) {
-  return '.'+this.name
+  return asSourceNode(this, '.'+this.name)
 }
 
 AST.If.prototype.compile = function (context) {
   var ind = context.indent()
-  var ret = 'if ('+this.cond.compile()+") {\n"
-  ret += this.block.compile(context)
-  ret += ind+"}"
+  var ret = ['if (', this.cond.compile(), ") {\n"]
+  ret.push(this.block.compile(context))
+  ret.push(ind+"}")
   if (this.elseIfs) {
     for (var i = 0; i < this.elseIfs.length; i++) {
       var ei = this.elseIfs[i]
-      ret += ' else if ('+ei.cond.compile(context)+") {\n"
-      ret += ei.block.compile(context)
-      ret += ind+"}"
+      ret.push(' else if (', ei.cond.compile(context), ") {\n")
+      ret.push(ei.block.compile(context))
+      ret.push(ind+"}")
     }
   }
-  return asSourceNode(this, ret+"\n")
+  ret.push("\n")
+  return asSourceNode(this, ret)
 }
 
 AST.While.prototype.compile = function (context) {
   var ind = context.indent()
-  var ret = 'while ('
-  ret += this.expr.compile(context, {omitTerminator: true})
-  ret += ') {\n'
-  ret += this.block.compile(context)
-  ret += ind + "}\n"
-  return ret
+  var ret = [
+    'while (',
+      this.expr.compile(context, {omitTerminator: true}),
+    ') {\n',
+      this.block.compile(context),
+    ind + "}\n"
+  ]
+  return asSourceNode(this, ret)
 }
 
 AST.For.prototype.compile = function (context) {

--- a/lib/targets/javascript.js
+++ b/lib/targets/javascript.js
@@ -1,7 +1,9 @@
 
-var AST    = require('../ast'),
-    types  = require('../types'),
-    repeat = require('../util').repeat
+var AST        = require('../ast'),
+    types      = require('../types'),
+    repeat     = require('../util').repeat,
+    sourcemap  = require('source-map'),
+    SourceNode = sourcemap.SourceNode
 
 
 // Context of the compiler as it's generating code ----------------------------
@@ -35,14 +37,26 @@ function compileStatement (context, stmt) {
   return stmt.compile(context, opts)
 }
 
+// Return a string as a SourceNode with position information copied from the
+// given node.
+function asSourceNode (node, ret) {
+  var name = node.constructor.name
+  if (!node._line)   { throw new Error('Missing line for '+name) }
+  if (!node._column) { throw new Error('Missing column for '+name) }
+  if (!node._file)   { throw new Error('Missing file for '+name) }
+  return new SourceNode(node._line, node._column, node._file, ret)
+}
+
 // JS code-generating compiler ------------------------------------------------
 
 AST.Root.prototype.compile = function () {
   // Compilation context
-  var context = new Context()
-  return this.statements.map(function (stmt) {
+  var context  = new Context()
+  var compiled = new SourceNode(1, 0, null, this.statements.map(function (stmt) {
     return compileStatement(context, stmt)
-  }).join('')
+  })).toStringWithSourceMap()
+  this.sourceMap = compiled.map
+  return compiled.code
 }
 
 AST.Binary.prototype.compile = function (context, opts) {
@@ -61,16 +75,17 @@ AST.Literal.prototype.compile  = function (context) {
 }
 
 AST.Assignment.prototype.compile = function (context, opts) {
-  var term = ";\n"
+  var term = ";\n",
+      ret  = null
   if (opts && opts.omitTerminator === true) { term = '' }
   if (this.type === 'var' || this.type === 'let') {
     // TODO: Register name in context scope and check for conflicts.
     var lvalue = this.lvalue.name
     if (this.rvalue !== false) {
       var rvalue = this.rvalue.compile(context)
-      return 'var '+lvalue+' '+this.op+' '+rvalue+term
+      ret = 'var '+lvalue+' '+this.op+' '+rvalue+term
     } else {
-      return 'var '+lvalue+term
+      ret = 'var '+lvalue+term
     }
   } else {
     // TODO: Handle more complex path assignments
@@ -80,8 +95,9 @@ AST.Assignment.prototype.compile = function (context, opts) {
       lvalue += item.compile(context)
     })
     var rvalue = this.rvalue.compile(context)
-    return lvalue+' '+this.op+' '+rvalue+term
+    ret = lvalue+' '+this.op+' '+rvalue+term
   }
+  return asSourceNode(this, ret)
 }
 
 AST.Function.prototype.compile = function (context) {
@@ -110,7 +126,7 @@ AST.Function.prototype.compile = function (context) {
   if (this.name) {
     ret += "\n"
   }
-  return ret
+  return asSourceNode(this, ret)
 }
 
 AST.Multi.prototype.compile = function (context) {
@@ -172,7 +188,7 @@ AST.Multi.prototype.compile = function (context) {
 
   context.decrementIndent()
   ret += context.indent()+"}\n"
-  return ret
+  return asSourceNode(this, ret)
 }
 
 
@@ -206,7 +222,7 @@ AST.Class.prototype.compile = function (context) {
     var methodName = node.name
     ret += name+".prototype."+methodName+" = "+node.compile(context)
   })
-  return ret
+  return asSourceNode(this, ret)
 }
 AST.Class.prototype.compilePreamble = function (context) {
   var letProperties = [],
@@ -280,7 +296,8 @@ AST.New.prototype.compile = function (context) {
       args = this.args.map(function (arg) {
         return arg.compile(context)
       }).join(', ')
-  return "(new "+name+"("+args+"))"
+  var ret = "(new "+name+"("+args+"))"
+  return asSourceNode(this, ret)
 }
 
 
@@ -288,7 +305,8 @@ AST.Call.prototype.compile = function (context) {
   var args = this.args.map(function (arg) {
     return arg.compile(context)
   })
-  return '('+args.join(', ')+')'
+  var ret = '('+args.join(', ')+')'
+  return asSourceNode(this, ret)
 }
 
 AST.Property.prototype.compile = function (context) {
@@ -308,7 +326,7 @@ AST.If.prototype.compile = function (context) {
       ret += ind+"}"
     }
   }
-  return ret+"\n"
+  return asSourceNode(this, ret+"\n")
 }
 
 AST.While.prototype.compile = function (context) {
@@ -339,11 +357,15 @@ AST.Chain.prototype.compile = function (context, opts) {
     ret += item.compile(context)
   })
   if (opts && opts.statement === true) { ret += ";\n" }
-  return ret
+  return asSourceNode(this, ret)
 }
 
 AST.Return.prototype.compile  = function (context) {
-  return 'return '+this.expr.compile(context)+";\n"
+  var ret = "return;\n"
+  if (this.expr) {
+    ret = 'return '+this.expr.compile(context)+";\n"
+  }
+  return asSourceNode(this, ret)
 }
 
 AST.Block.prototype.compile = wrapContextIndent(function (context) {

--- a/lib/targets/javascript.js
+++ b/lib/targets/javascript.js
@@ -129,6 +129,25 @@ AST.Function.prototype.compile = function (context) {
   return asSourceNode(this, ret)
 }
 
+function interpose (arr, sep) {
+  var newArr  = [],
+      len     = arr.length,
+      lastIdx = len - 1
+  for (var i = 0; i < len; i++) {
+    newArr.push(arr[i])
+    if (i !== lastIdx) {
+      newArr.push(sep)
+    }
+  }
+  return newArr
+}
+Array.prototype.extend = function (other) {
+  var len = other.length
+  for (var i = 0; i < len; i++) {
+    this.push(other[i])
+  }
+}
+
 AST.Multi.prototype.compile = function (context) {
   // console.log(this)
   var args = this.args.map(function (arg) { return arg.name }),
@@ -363,11 +382,11 @@ AST.For.prototype.compile = function (context) {
 }
 
 AST.Chain.prototype.compile = function (context, opts) {
-  var ret = this.name
+  var ret = [this.name]
   this.tail.forEach(function (item) {
-    ret += item.compile(context)
+    ret.push(item.compile(context))
   })
-  if (opts && opts.statement === true) { ret += ";\n" }
+  if (opts && opts.statement === true) { ret.push(";\n") }
   return asSourceNode(this, ret)
 }
 

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
   "devDependencies": {
     "mocha": "~2.2.1",
     "esprima": "~2.1.0",
-    "lodash": "~3.6.0"
+    "lodash": "~3.6.0",
+    "source-map": "~0.4.2"
   },
   "devDependencies": {
     "mocha": "~2.2.1",
     "esprima": "~2.1.0",
     "lodash": "~3.6.0",
+    "source-map": "~0.4.2",
     "xregexp": "~2.0.0",
     "blanket": "~1.1.6",
     "mocha-lcov-reporter": "~0.0.2",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "mocha": "~2.2.1",
     "esprima": "~2.1.0",
     "lodash": "~3.6.0",
-    "source-map": "~0.4.2"
+    "source-map": "~0.4.2",
+    "inline-source-map-comment": "~1.0.5"
   },
   "devDependencies": {
     "mocha": "~2.2.1",


### PR DESCRIPTION
This gets us basic source-map support in compiler output and in command-line output.

#### Through the API

```js
var tree = parseAndWalk(source)
var code = tree.compile()
// tree.sourceMap will now have the correct generated source-map object
```

#### Through the command-line

```bash
bin/hb -m compile examples/classes.hb
# Output will have a source-map comment at the bottom
```