### PR TITLE
Class property flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ lib/grammar.js
 lib/grammar2.js
 test/spec
 .srclib-cache
+_site
+coverage.html
 
 # Ignore Vim swap files
 *.swp

--- a/lib/types.js
+++ b/lib/types.js
@@ -159,7 +159,7 @@ Function.prototype.inspect = function () {
 }
 Function.prototype.equals = function (other) {
   // If they're not both functions then they're definitely not equal
-  if (this.prototype !== other.prototype) {
+  if (this.constructor !== other.constructor) {
     return false
   }
   // Args must be the same length
@@ -173,6 +173,8 @@ Function.prototype.equals = function (other) {
     args[i] = ta.equals(oa)
   }
   if (!args.every(isTrue)) { return false }
+  // Simple null return checks (should be able to deprecate this soon)
+  if (this.ret === null || other.ret === null) { return this.ret === other.ret }
   // Finally compare types of their returns
   return this.ret.equals(other.ret)
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -39,6 +39,10 @@ Instance.prototype.equals = function (other) {
 Instance.prototype.inspect = function () { return "'"+this.type.inspect() }
 
 
+var Flags = {
+  ReadOnly: 'r'
+}
+
 // Types ----------------------------------------------------------------------
 
 function Object (supertype) {
@@ -46,6 +50,9 @@ function Object (supertype) {
   this.intrinsic  = true
   // Maps property names (strings) to Types
   this.properties = {}
+  // Flags about properties; maps name (string) to optional flags (string)
+  //   r = read-only
+  this.propertiesFlags = {}
   // List of initializers for the type
   this.initializers = []
 }
@@ -58,6 +65,13 @@ Object.prototype.getTypeOfProperty = function (name, fromNode) {
 Object.prototype.setTypeOfProperty = function (name, type) {
   // TODO: Check that it's not overwriting properties
   this.properties[name] = type
+}
+Object.prototype.getFlagsOfProperty = function (name) {
+  var flags = this.propertiesFlags[name]
+  return (flags ? flags : null)
+}
+Object.prototype.setFlagsOfProperty = function (name, flags) {
+  this.propertiesFlags[name] = flags
 }
 Object.prototype.addInitializer = function (initFunction) {
   this.initializers.push(initFunction)
@@ -187,6 +201,7 @@ Multi.prototype.addFunctionNode = function (functionNode) {
 
 
 module.exports = {
+  Flags: Flags,
   Type: Type,
   Instance: Instance,
   Any: Any,

--- a/lib/types.js
+++ b/lib/types.js
@@ -73,6 +73,11 @@ Object.prototype.getFlagsOfProperty = function (name) {
 Object.prototype.setFlagsOfProperty = function (name, flags) {
   this.propertiesFlags[name] = flags
 }
+// Checks if a given property has a certain flag set
+Object.prototype.hasPropertyFlag = function (name, flag) {
+  var flags = this.getFlagsOfProperty(name)
+  return (flags && flags.indexOf(flag) !== -1)
+}
 Object.prototype.addInitializer = function (initFunction) {
   this.initializers.push(initFunction)
 }

--- a/lib/typesystem.js
+++ b/lib/typesystem.js
@@ -282,6 +282,12 @@ TypeSystem.prototype.visitPath = function (node, scope) {
         // Finally look up the type of the property and box it up
         var newType = type.getTypeOfProperty(propertyName, item)
         lvalueType = new types.Instance(newType)
+        // Also check the flags to make sure we're not trying to write to
+        // a read-only property
+        var flags = type.getFlagsOfProperty(propertyName)
+        if (flags && flags.indexOf(types.Flags.ReadOnly) !== -1) {
+          throw new TypeError('Trying to assign to read-only property: '+propertyName, node)
+        }
         break
       default:
         throw new TypeError('Cannot handle item in path of type: '+item.constructor.name, node)
@@ -485,15 +491,19 @@ TypeSystem.prototype.visitFunction = function (node, parentScope, immediate) {
   node.scope = functionScope
 
   // Build up the args to go into the type definition
-  var typeArgs = []
+  var typeArgs = [], n = 0
   node.args.forEach(function (arg) {
     // Deprecated simplistic type lookup:
     //   var argType = self.findByName(arg.type)
+    if (!arg.type) {
+      throw new TypeError('Missing type for argument '+n, node)
+    }
     var argType = self.resolveType(arg.type)
     // Setup a local Instance in the function's scope for the argument
     functionScope.setLocal(arg.name, new types.Instance(argType))
     // Add the type to the type's args
     typeArgs.push(argType)
+    n += 1
   })
   type.args = typeArgs
 

--- a/lib/typesystem.js
+++ b/lib/typesystem.js
@@ -284,8 +284,7 @@ TypeSystem.prototype.visitPath = function (node, scope) {
         lvalueType = new types.Instance(newType)
         // Also check the flags to make sure we're not trying to write to
         // a read-only property
-        var flags = type.getFlagsOfProperty(propertyName)
-        if (flags && flags.indexOf(types.Flags.ReadOnly) !== -1) {
+        if (type.hasPropertyFlag(propertyName, types.Flags.ReadOnly)) {
           throw new TypeError('Trying to assign to read-only property: '+propertyName, node)
         }
         break

--- a/lib/typesystem.js
+++ b/lib/typesystem.js
@@ -154,7 +154,10 @@ TypeSystem.prototype.visitClassDefinition = function (node, scope, klass) {
         }
         // Create the property on the object with the resolved type
         klass.setTypeOfProperty(propertyName, propertyType)
-        // TODO: Add read-only flags when the assignment .type is "let"
+        // Add read-only flags for this property when the assignment .type is "let"
+        if (stmt.type === 'let') {
+          klass.setFlagsOfProperty(propertyName, 'r')
+        }
         break
       case AST.Function:
         self.visitClassFunction(stmt, thisScope, klass)

--- a/lib/typesystem/bootstrap.js
+++ b/lib/typesystem/bootstrap.js
@@ -30,9 +30,11 @@ module.exports = function (TypeSystem) {
     var consoleType = new types.Object(this.root.getLocal('Object'))
     consoleType.intrinsic = true
     consoleType.name      = 'BuiltinConsole'
-    // Create the `log(...)` function and add it to the console's type
+    // Create the `log(...)` function and add it to the console's type as a
+    // read-only property
     var consoleLogFunction = new types.Function(rootObject, [this.root.getLocal('Any')])
-    consoleType.properties['log'] = consoleLogFunction 
+    consoleType.setTypeOfProperty('log', consoleLogFunction)
+    consoleType.setFlagsOfProperty('log', 'r')
     // Create a faux instance of the console and add it to the root scope
     var consoleInstance = new types.Instance(consoleType)
     this.root.setLocal('console', consoleInstance)

--- a/test/test-system.js
+++ b/test/test-system.js
@@ -69,6 +69,24 @@ describe('System', function () {
         expect(result).to.eql(3)
       })
     })
+
+    describe('with a let-property in its definition', function () {
+      var source = "class A {\n"+
+                   "  let b: Integer = 0\n"+
+                   "  init () { }\n"+
+                   "}\n"+
+                   "var a = new A()\n"
+      it('should parse the basic definition', function () {
+        var tree = parseAndWalk(source)
+        expect(tree).to.be.ok()
+      })
+      it('should error when trying to write to that property', function () {
+        var extendedSource = source+"a.b = 1"
+        expect(function () {
+          parseAndWalk(extendedSource)
+        }).to.throwException(/assign to read-only property/)
+      })
+    })
   })
 
   xdescribe('given a while-true program', function () {


### PR DESCRIPTION
Add flags to class properties. Currently this only tracks read-only properties, but opens the door to more useful flags down the road.