### PR TITLE
Grammar improvements

### DIFF
--- a/bin/hbn
+++ b/bin/hbn
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 var path         = require('path'),
-    libDirectory = path.join(path.dirname(__filename), '..', 'src')
+    srcDirectory = path.join(path.dirname(__filename), '..', 'src')
 
-require(path.join(libDirectory, 'command-native'))
+require(path.join(srcDirectory, 'command-native'))
 

--- a/examples/trivial.hb
+++ b/examples/trivial.hb
@@ -19,6 +19,7 @@ class A {
 }
 console.log("Foo bar.")
 let e = new A()
+let f = e.b
 console.log(e.b)
 console.log(e.d())
 

--- a/src/command.js
+++ b/src/command.js
@@ -107,9 +107,14 @@ function compileFile (args) {
   var filePath      = fileFromArgs(args, 0),
       // Get the directory of the file for the import-path
       fileDirectory = path.dirname(filePath)
-  var compiler = new Compiler()
-  compiler.importPath.push(fileDirectory)
-  var file = compiler.compile(filePath, compileOpts)
+  try {
+    var compiler = new Compiler()
+    compiler.importPath.push(fileDirectory)
+    var file = compiler.compile(filePath, compileOpts)
+  } catch (err) {
+    reportError(err)
+    process.exit(1)
+  }
   return file
 }
 

--- a/src/parser-extension.js
+++ b/src/parser-extension.js
@@ -98,16 +98,24 @@ module.exports = function (p) {
     return new AST.Return(expr)
   }
 
-  p.parseCall = function (expr) {
-    return new AST.Call(expr)
+  p.parseCall = function (base, call) {
+    return new AST.Call(base, call)
   }
 
-  p.parseProperty = function (name) {
-    return new AST.Property(name)
+  p.parseProperty = function (base, property) {
+    return new AST.Property(base, property)
+  }
+
+  p.parseIdentifier = function (name) {
+    return new AST.Identifier(name)
   }
 
   p.parsePath = function (name, path) {
     return new AST.Path(name, path)
+  }
+
+  p.parsePathProperty = function (name) {
+    return new AST.Identifier(name)
   }
 
   p.parseFunctionType = function (args, ret) {

--- a/src/targets/javascript.js
+++ b/src/targets/javascript.js
@@ -466,7 +466,7 @@ AST.Identifier.prototype.compile = function (context, opts) {
 
 AST.Call.prototype.compile = function (context, opts) {
   var args = this.args.map(function (arg) {
-    return arg.compile(context)
+    return arg.compile(context, {omitTerminator: true})
   })
   var ret = [this.base.compile(context), '(']
   var length = args.length, lastIndex = args.length - 1

--- a/src/targets/llvm.js
+++ b/src/targets/llvm.js
@@ -289,24 +289,39 @@ AST.Assignment.prototype.compileToStorable = function (ctx, blockCtx, lvalue) {
     }
     var item = path[i]
     switch (item.constructor) {
-    case AST.Property:
-      assertInstanceOf(itemType, types.Instance)
-      // Make sure it's pointing to an Object
-      var objectType = itemType.type
-      assertInstanceOf(objectType, types.Object)
-      var nativeObject = objectType.getNativeObject()
-      // Now get the property
-      var propName = item.name,
-          propPtr  = nativeObject.buildStructGEPForProperty(ctx, itemValue, propName)
-      // If it's the end of the path then we return the pointer since it's storable
-      if (isLast) {
-        return propPtr
-      }
-      itemType = new types.Instance(itemType.getTypeOfPropertyName(propName))
-      itemValue = ctx.builder.buildLoad(propPtr, propName)
-      break
-    default:
-      throw new ICE('Cannot handle path item type: '+item.constructor.name)
+      case AST.Identifier:
+        // Unbox and ensure we've got an Object we can work with
+        assertInstanceOf(itemType, types.Instance)
+        var objType = itemType.type
+        assertInstanceOf(objType, types.Object)
+        var nativeObj = objType.getNativeObject(),
+            propName  = item.name,
+            propType  = item.type,
+            propPtr   = nativeObj.buildStructGEPForProperty(ctx, itemValue, propName)
+        // Return storable pointer if we're the last item in the chain
+        if (isLast) { return propPtr }
+        // Otherwise build a dereference
+        itemType  = propType
+        itemValue = ctx.builder.buildLoad(propPtr, propName)
+        break
+   /* case AST.Property:
+        assertInstanceOf(itemType, types.Instance)
+        // Make sure it's pointing to an Object
+        var objectType = itemType.type
+        assertInstanceOf(objectType, types.Object)
+        var nativeObject = objectType.getNativeObject()
+        // Now get the property
+        var propName = item.name,
+            propPtr  = nativeObject.buildStructGEPForProperty(ctx, itemValue, propName)
+        // If it's the end of the path then we return the pointer since it's storable
+        if (isLast) {
+          return propPtr
+        }
+        itemType = new types.Instance(itemType.getTypeOfPropertyName(propName))
+        itemValue = ctx.builder.buildLoad(propPtr, propName)
+        break */
+      default:
+        throw new ICE('Cannot handle path item type: '+item.constructor.name)
     }
   }
 }
@@ -326,6 +341,147 @@ AST.Assignment.prototype.compileNamed = function (ctx, blockCtx) {
   assertInstanceOf(rvalue, Buffer, 'Received non-Buffer from Node#compilerToValue')
   // Get the slot pointer
   blockCtx.slots.buildSet(ctx, this.lvalue.name, rvalue)
+}
+
+AST.Property.prototype.compile = function (ctx, blockCtx, exprCtx) {
+  this.compileToValue(ctx, blockCtx, exprCtx)
+}
+
+AST.Property.prototype.compileToValue = function (ctx, blockCtx, exprCtx) {
+  var base      = this.base,
+      parent    = this.parent,
+      property  = this.property,
+      type      = null,
+      value     = null
+
+  if (parent === null) {
+    // Start off with an Identifier
+    assertInstanceOf(this.base, AST.Identifier)
+    var retCtx = {}
+    this.base.compile(ctx, blockCtx, retCtx)
+    type  = retCtx.type
+    value = retCtx.value
+
+  } else {
+    type  = exprCtx.type
+    value = exprCtx.value
+  }
+  assertInstanceOf(value, Buffer)
+  var ret = this.property.compileToValue(ctx, blockCtx, {type: type, value: value})
+  if (!ret) {
+    throw new ICE("Encountered a null return value")
+  }
+  return ret
+}
+
+AST.Call.prototype.compileInstanceMethodCall = function (ctx, blockCtx, exprCtx) {
+  var recvValue    = exprCtx.value,
+      recvInstance = exprCtx.type,
+      instance     = this.base.type,
+      method       = instance.type
+  assertInstanceOf(recvValue, Buffer)
+  assertInstanceOf(recvInstance.type, types.Object)
+  assertInstanceOf(method, types.Function)
+  // Get the object we're going to use and compile the argument values
+  var recvObj   = recvInstance.type.getNativeObject(),
+      argValues = this.args.map(function (arg) {
+        return arg.compileToValue(ctx, blockCtx)
+      })
+  // Get the function to call
+  var methodFn = method.getNativeFunction()
+  // And add the receiver object pointer and call the function
+  argValues.unshift(recvValue)
+  var retValue  = ctx.builder.buildCall(methodFn.getPtr(), argValues, '')
+  exprCtx.type  = this.type
+  exprCtx.value = retValue
+  return retValue
+}
+
+AST.Call.prototype.compile = function (ctx, blockCtx, exprCtx) {
+  this.compileToValue(ctx, blockCtx, exprCtx)
+}
+AST.Call.prototype.compileToValue = function (ctx, blockCtx, exprCtx) {
+  var parent = this.parent,
+      type   = null,
+      value  = null
+
+  // First we need to check for it being an instance method
+  while (parent !== null) {
+    var methodType = this.base.type
+    if (!(methodType instanceof types.Instance)) { break }
+    // Unbox the instance and check if it's an instace method
+    methodType = methodType.type
+    if (!methodType.isInstanceMethod) { break }
+    // If it was an instance method then we'll go directly to that
+    // compilation path
+    return this.compileInstanceMethodCall(ctx, blockCtx, exprCtx)
+  }
+
+  if (parent === null) {
+    // Make sure we have a real Identifier to start off with
+    assertInstanceOf(this.base, AST.Identifier)
+    var retCtx = {}
+    this.base.compile(ctx, blockCtx, retCtx)
+    type  = retCtx.type
+    value = retCtx.value
+
+  } else {
+    baseType  = exprCtx.type
+    baseValue = exprCtx.value
+    var retCtx = {type: baseType, value: baseValue}
+    this.base.compile(ctx, blockCtx, retCtx)
+    type  = retCtx.type
+    value = retCtx.value
+  }
+  assertInstanceOf(type, types.Instance)
+  var funcType  = type.type,
+      argValues = this.args.map(function (arg) {
+        return arg.compileToValue(ctx, blockCtx)
+      })
+  // Look up the native function and call it
+  var nativeFn = funcType.getNativeFunction()
+  assertInstanceOf(nativeFn, NativeFunction)
+  var fnPtr = nativeFn.getPtr()
+  // Build return call and update the context to return
+  var retValue = ctx.builder.buildCall(fnPtr, argValues, '')
+  tryUpdatingExpressionContext(exprCtx, this.type, retValue)
+  return retValue
+}
+
+function tryUpdatingExpressionContext (exprCtx, type, value) {
+  if (!exprCtx) { return }
+  exprCtx.type  = type
+  exprCtx.value = value
+}
+
+AST.Identifier.prototype.compile = function (ctx, blockCtx, exprCtx) {
+  this.compileToValue(ctx, blockCtx, exprCtx)
+}
+AST.Identifier.prototype.compileToValue = function (ctx, blockCtx, exprCtx) {
+  var parent   = this.parent,
+      newType  = null,
+      newValue = null
+
+  if (parent === null) {
+    // Look up ourselves rather than building off a parent
+    var pair = getTypeAndSlotsForName(ctx, blockCtx, this.name)
+    newValue = pair[0].buildGet(ctx, this.name)
+    newType  = pair[1]
+  } else {
+    var type  = exprCtx.type,
+        value = exprCtx.value
+    // Check the types and then build the GEP
+    assertInstanceOf(type, types.Instance)
+    var objType   = type.type,
+        nativeObj = objType.getNativeObject()
+
+    // Build the pointer and load it into a value
+    var ptr  = nativeObj.buildStructGEPForProperty(ctx, value, this.name)
+    newType  = this.type
+    newValue = ctx.builder.buildLoad(ptr, this.name)
+  }
+  tryUpdatingExpressionContext(exprCtx, newType, newValue)
+  return newValue
 }
 
 AST.Literal.prototype.compileToValue = function (ctx, blockCtx) {

--- a/src/targets/llvm/builtins.js
+++ b/src/targets/llvm/builtins.js
@@ -33,9 +33,10 @@ function compile (ctx, mainEntry, root) {
       consoleType     = consoleInstance.type,
       logType         = consoleType.getTypeOfProperty('log')
 
-  // Create the NativeFunction for logging strings
+  // Create the NativeFunction for logging strings and define it as
+  // externally (computes type and builds external function pointer).
   var log = new NativeFunction('TBuiltinConsole_mlog', [rootScope.getLocal('String')], rootScope.getLocal('Void'))
-  log.computeType()
+  log.defineExternal(ctx)
   logType.setNativeFunction(log)
   /*
   log.defineBody(ctx, function (entry) {

--- a/src/targets/llvm/native-function.js
+++ b/src/targets/llvm/native-function.js
@@ -32,6 +32,10 @@ NativeFunction.prototype.computeType = function () {
   }
   this.type = new LLVM.FunctionType(ret, args, false)
 }
+NativeFunction.prototype.defineExternal = function (ctx) {
+  this.computeType()
+  this.fn = NativeFunction.addExternalFunction(ctx, this.name, this.ret, this.args)
+}
 NativeFunction.prototype.defineBody = function (ctx, cb) {
   if (!this.type) {
     this.computeType()

--- a/src/targets/llvm/native-types.js
+++ b/src/targets/llvm/native-types.js
@@ -40,5 +40,10 @@ function nativeTypeForType (type) {
   }
 }
 
+// Add native names for some types
+types.Module.prototype.getNativeName = function () {
+  return 'M'+this.name
+}
+
 module.exports = {nativeTypeForType: nativeTypeForType}
 

--- a/src/types.js
+++ b/src/types.js
@@ -108,10 +108,6 @@ Module.prototype.addChild = function (child) {
   var childName = child.name
   this.setTypeOfProperty(childName, child)
 }
-Module.prototype.getNativeName = function () {
-  // TODO: Incorporate parents
-  return 'M'+this.name
-}
 Module.prototype.inspect = function () { return '.'+this.name }
 
 

--- a/src/typesystem.js
+++ b/src/typesystem.js
@@ -422,6 +422,8 @@ TypeSystem.prototype.visitPath = function (node, scope) {
         if (type.hasPropertyFlag(propertyName, types.Flags.ReadOnly)) {
           throw new TypeError('Trying to assign to read-only property: '+propertyName, node)
         }
+        // Set the type that is going to be returned at this stage on the item
+        item.type = lvalueType
         break
       default:
         throw new TypeError('Cannot handle item in path of type: '+item.constructor.name, node)

--- a/test/test-system.js
+++ b/test/test-system.js
@@ -75,7 +75,10 @@ describe('System', function () {
       })
       it('should produce an expected result', function () {
         var extended = source+"return a.c(1)\n",
-            tree     = parseAndWalk(extended),
+            tree     = parseAndWalk(extended)
+              console.log(tree.compile())
+
+          
             result   = runCompiledCode(tree)
         expect(result).to.eql(3)
       })
@@ -83,13 +86,13 @@ describe('System', function () {
         var extended = source+"a.c(1, 2)\n"
         expect(function () {
           parseAndWalk(extended)
-        }).to.throwException(/Wrong number of arguments/)
+        }).to.throwException(/Argument length mismatch/)
       })
       it('should fail on parsing mismatched argument types', function () {
         var extended = source+"a.c(\"1\")\n"
         expect(function () {
           parseAndWalk(extended)
-        }).to.throwException(/Argument mismatch/)
+        }).to.throwException(/Argument type mismatch/)
       })
     })
 


### PR DESCRIPTION
This restructures value member paths in the language grammar to make the AST more usable and future-feature/development-friendly.

Given the following program:

```
a.b.c(d)
```

The old grammar would roughly parse to:

```
[a, [b, c, (d)]]
```

The new grammar parses roughly to:

```
[a, [b, [c(d)]]]
```

As you can see, the new grammar parses to a tree of all 1-degree-nodes. This transforms more easily to a recursive approach for type-checking and code generation. (Additionally all the nodes have references to their parent and children nodes.) This recursive approach (oddly enough, sort of) actually works better than the roughly-iterative approach of the old grammar design.