### PR TITLE
Defaults for class properties in LLVM target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - "0.12"
-  - "iojs"
+  - "iojs-v1.0.4"
 before_install:
   # Setup sources and keys for LLVM
   - sudo sh -c "echo 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.5 main' >> /etc/apt/sources.list"

--- a/examples/classes.hb
+++ b/examples/classes.hb
@@ -17,4 +17,5 @@ class Foo {
 
 var f = new Foo("3")
 console.log(f.bar)
+console.log(f.baz)
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "concat-stream": "~1.4.8"
   },
   "devDependencies": {
-    "typescript": "~1.5.0-alpha",
+    "typescript": "1.5.0-beta",
     "jake": "~8.0.12",
     "mocha": "~2.2.1",
     "esprima": "~2.1.0",

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -142,7 +142,9 @@ export class Export extends Node {
 export class Class extends Node {
   name:         any
   definition:   any
-  initializers: any[]
+  // Properties and initializers are extracted from the definition by AST
+  properties:   any[] = []
+  initializers: any[] = []
   // Computed by the typesystem
   type:         any
 
@@ -151,9 +153,18 @@ export class Class extends Node {
     this.name       = name
     this.definition = block
     // Computed nodes from the definition
-    this.initializers = this.definition.statements.filter(function (stmt) {
-      return (stmt instanceof Init)
-    })
+    var statements = this.definition.statements
+    for (var i = 0; i < statements.length; i++) {
+      var stmt = statements[i]
+      switch (stmt.constructor) {
+        case Init:
+          this.initializers.push(stmt)
+          break
+        case Assignment:
+          this.properties.push(stmt)
+          break
+      }
+    }
   }
   print() {
     out.write('export class '+this.name+" ")

--- a/src/targets/llvm.js
+++ b/src/targets/llvm.js
@@ -1095,6 +1095,8 @@ AST.Class.prototype.compilePreinitializer = function (ctx, blockCtx, nativeObjec
       var prop  = properties[i],
           name  = prop.lvalue.name,
           value = prop.rvalue
+      // Skip this property if there's no default value for it
+      if (value === false) { continue }
       // Set the value on the property of the new instance
       var ptr = nativeObject.buildStructGEPForProperty(ctx, recv, name)
       // Compile the value to a value

--- a/src/targets/llvm.js
+++ b/src/targets/llvm.js
@@ -926,7 +926,7 @@ function predefineTypes (ctx, block) {
   })
 }
 
-function genericCompileFunction (ctx, nativeFn, node) {
+function genericCompileFunction (ctx, nativeFn, node, preStatementsCb) {
   var hasThisArg = (node instanceof AST.Init),
       block      = node.block
   // Predefine to be safe
@@ -954,7 +954,12 @@ function genericCompileFunction (ctx, nativeFn, node) {
         // Store the argument value in the slot
         slots.buildSet(ctx, argName, argValue)
       }
-    })
+      // If there was a callback to run before compiling statements, then
+      // go ahead an call it
+      if (preStatementsCb) {
+        preStatementsCb(blockCtx, slots)
+      }
+    })//compileBlock
 
     // If it's returning Void and the last statement isn't a return then
     // go ahead an insert one for safety
@@ -1073,13 +1078,42 @@ AST.Class.prototype.compile = function (ctx, blockCtx) {
   // Define the native object in the context
   nativeObject.define(ctx)
   // Build the initializers for the class
+  this.compilePreinitializer(ctx, blockCtx, nativeObject)
   this.compileInitializers(ctx, blockCtx, nativeObject)
   this.compileInstanceMethods(ctx, blockCtx, nativeObject)
 }
+AST.Class.prototype.compilePreinitializer = function (ctx, blockCtx, nativeObject) {
+  var initArgs     = [new types.Instance(this.type)],
+      initRet      = blockCtx.block.scope.get('Void'),
+      properties   = this.properties,
+      nativeObject = this.type.getNativeObject()
+  // Native function for the pre-initializer
+  var fn = new NativeFunction(nativeObject.internalName+'_pi', initArgs, initRet)
+  fn.defineBody(ctx, function (entry) {
+    var recv = GetParam(fn.getPtr(), 0)
+    for (var i = 0; i < properties.length; i++) {
+      var prop  = properties[i],
+          name  = prop.lvalue.name,
+          value = prop.rvalue
+      // Set the value on the property of the new instance
+      var ptr = nativeObject.buildStructGEPForProperty(ctx, recv, name)
+      // Compile the value to a value
+      value = value.compileToValue(ctx, blockCtx)
+      ctx.builder.buildStore(value, ptr, '.'+name)
+    }
+    ctx.builder.buildRetVoid()
+  })
+  // Expose the native function on the type
+  this.type.nativePreinitializer = fn
+}
 AST.Class.prototype.compileInitializers = function (ctx, blockCtx, nativeObject) {
-  var type         = this.type,
-      nativeObject = type.getNativeObject(),
-      initializers = this.initializers
+  var type           = this.type,
+      preinitializer = this.type.nativePreinitializer,
+      nativeObject   = type.getNativeObject(),
+      initializers   = this.initializers
+  if (!preinitializer) {
+    throw new TypeError('Missing preinitializer on class', this)
+  }
   // Build and compile a native function for each initializer function
   for (var i = 0; i < initializers.length; i++) {
     var init         = initializers[i],
@@ -1091,8 +1125,13 @@ AST.Class.prototype.compileInitializers = function (ctx, blockCtx, nativeObject)
     initArgs.unshift(new types.Instance(type))
     // Create the native function
     var fn = new NativeFunction(internalName, initArgs, initType.ret)
-    genericCompileFunction(ctx, fn, init)
-
+    // Need to add a call to the preinitializer
+    genericCompileFunction(ctx, fn, init, function (blockCtx, slots) {
+      var ptr  = preinitializer.getPtr(),
+          recv = slots.buildGet(ctx, 'this')
+      // Call the preinitializer
+      ctx.builder.buildCall(ptr, [recv], '')
+    })
     // Add this native function to the native object's list of initializers
     // and to the initializer function type
     nativeObject.addInitializer(fn)

--- a/src/targets/llvm.js
+++ b/src/targets/llvm.js
@@ -1095,7 +1095,6 @@ AST.Class.prototype.compilePreinitializer = function (ctx, blockCtx, nativeObjec
       var prop  = properties[i],
           name  = prop.lvalue.name,
           value = prop.rvalue
-      // Skip this property if there's no default value for it
       if (value === false) { continue }
       // Set the value on the property of the new instance
       var ptr = nativeObject.buildStructGEPForProperty(ctx, recv, name)
@@ -1130,10 +1129,10 @@ AST.Class.prototype.compileInitializers = function (ctx, blockCtx, nativeObject)
     // Need to add a call to the preinitializer
     genericCompileFunction(ctx, fn, init, function (blockCtx, slots) {
       var ptr  = preinitializer.getPtr(),
-          recv = slots.buildGet(ctx, 'this')
-      // Call the preinitializer
+          recv = GetParam(fn.getPtr(), 0)
       ctx.builder.buildCall(ptr, [recv], '')
     })
+
     // Add this native function to the native object's list of initializers
     // and to the initializer function type
     nativeObject.addInitializer(fn)

--- a/src/typesystem.ts
+++ b/src/typesystem.ts
@@ -322,7 +322,8 @@ TypeSystem.prototype.visitClassDefinition = function (node: AST.Block, scope, kl
           throw new TypeError('Missing type for class slot: '+propertyName)
         }
         var propertyType = self.resolveType(stmt.lvalue.immediateType, scope)
-        // Check that the default (rvalue) is constant if present
+        // Visit and then check that the default (rvalue) is constant if present
+        self.visitExpression(stmt.rvalue, scope)
         // TODO: Smarter checking of constant-ness of default values when it's "let"
         if (stmt.rvalue && !(stmt.rvalue instanceof AST.Literal)) {
           throw new TypeError('Cannot handle non-literal default for property: '+propertyName)

--- a/src/typesystem.ts
+++ b/src/typesystem.ts
@@ -313,25 +313,28 @@ TypeSystem.prototype.visitClassDefinition = function (node: AST.Block, scope, kl
   node.statements.forEach(function (stmt) {
     switch (stmt.constructor) {
       case AST.Assignment:
-        if (stmt.type !== 'var' && stmt.type !== 'let') {
-          throw new TypeError('Unexpected assignment type: '+stmt.type, stmt)
+        var assg: AST.Assignment = stmt
+        if (assg.type !== 'var' && assg.type !== 'let') {
+          throw new TypeError('Unexpected assignment type: '+assg.type, assg)
         }
-        var propertyName = stmt.lvalue.name
+        var propertyName = assg.lvalue.name
         // Check that there's a type specified for this slot
-        if (!stmt.lvalue.immediateType) {
+        if (!assg.lvalue.immediateType) {
           throw new TypeError('Missing type for class slot: '+propertyName)
         }
-        var propertyType = self.resolveType(stmt.lvalue.immediateType, scope)
+        var propertyType = self.resolveType(assg.lvalue.immediateType, scope)
         // Visit and then check that the default (rvalue) is constant if present
-        self.visitExpression(stmt.rvalue, scope)
+        if (assg.rvalue !== false) {
+          self.visitExpression(assg.rvalue, scope)
+        }
         // TODO: Smarter checking of constant-ness of default values when it's "let"
-        if (stmt.rvalue && !(stmt.rvalue instanceof AST.Literal)) {
+        if (assg.rvalue && !(assg.rvalue instanceof AST.Literal)) {
           throw new TypeError('Cannot handle non-literal default for property: '+propertyName)
         }
         // Create the property on the object with the resolved type
         klass.setTypeOfProperty(propertyName, propertyType)
         // Add read-only flags for this property when the assignment .type is "let"
-        if (stmt.type === 'let') {
+        if (assg.type === 'let') {
           klass.setFlagsOfProperty(propertyName, 'r')
         }
         break

--- a/test/llvm/helper.js
+++ b/test/llvm/helper.js
@@ -34,7 +34,17 @@ function runSync (cmd, input) {
   if (input !== undefined) {
     opts.input = input
   }
-  return child_process.execSync(cmd, opts)
+  try {
+    return child_process.execSync(cmd, opts)
+  } catch (err) {
+    if (err.stdout) {
+      console.error(err.stdout.toString())
+    }
+    if (err.stderr) {
+      console.error(err.stderr.toString())
+    }
+    throw err
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
This makes the following actually work:

```
class A {
  var b: String = "c"
  init () { }
}
var a = new A()
console.log(a.b)
```

The above will print `c`.