### PR TITLE
Better calling of intrinsics

### DIFF
--- a/examples/extending-classes.hb
+++ b/examples/extending-classes.hb
@@ -1,0 +1,7 @@
+class String {
+  func identity () -> String {
+    return this
+  }
+}
+var a = "a"
+console.log(a.identity())

--- a/src/targets/llvm.ts
+++ b/src/targets/llvm.ts
@@ -624,6 +624,8 @@ export class LLVMCompiler {
           receiverType     = receiverInstance.type
       if (receiverType.intrinsic === true) {
         // Need to do a little bit of special handling for intrinsics
+        // TODO: Instead of checking the receiver, check the actual method
+        //       to see if it's an intrinsic instance method.
         return this.compileIntrinsicInstanceMethodCall(call, blockCtx, exprCtx)
       } else {
         // If it was an instance method then we'll go directly to that

--- a/src/targets/llvm.ts
+++ b/src/targets/llvm.ts
@@ -622,14 +622,11 @@ export class LLVMCompiler {
       if (!methodType.isInstanceMethod) { break }
       var receiverInstance = parent.baseType,
           receiverType     = receiverInstance.type
-      if (receiverType.intrinsic === true) {
-        // Need to do a little bit of special handling for intrinsics
-        // TODO: Instead of checking the receiver, check the actual method
-        //       to see if it's an intrinsic instance method.
+      // Check if we need to call through the instrinsic shim or can just
+      // do a regular instance method call
+      if (methodType.isIntrinsic === true) {
         return this.compileIntrinsicInstanceMethodCall(call, blockCtx, exprCtx)
       } else {
-        // If it was an instance method then we'll go directly to that
-        // compilation path
         return this.compileInstanceMethodCall(call, blockCtx, exprCtx)
       }
     }
@@ -709,15 +706,14 @@ export class LLVMCompiler {
     var self         = this,
         recvValue    = exprCtx.value,
         recvInstance = exprCtx.type,
-        recvType     = unboxInstanceType(recvInstance, types.Object),
+        recvType     = unboxInstanceType(recvInstance),
         instance     = call.base.type,
         method       = instance.type
 
     assertInstanceOf(recvValue, Buffer)
     assertInstanceOf(method, types.Function)
     // Get the object we're going to use and compile the argument values
-    var recvObj   = recvType.getNativeObject(),
-        argValues = call.args.map(function (arg) {
+    var argValues = call.args.map(function (arg) {
           return self.compileExpression(arg, blockCtx)
         })
     // Get the function to call

--- a/src/types.ts
+++ b/src/types.ts
@@ -247,7 +247,7 @@ export class Function extends Type {
   isInstanceMethod: boolean
   // If this is an intrinsic instance method shimming for a module method,
   // this points to that module method to call in place of this shim.
-  shimFor: any
+  private shimFor: any = null
 
   constructor(supertype, args?: Type[], ret?: Type) {
     super(supertype)
@@ -302,6 +302,13 @@ export class Function extends Type {
     if (this.ret === null || other.ret === null) { return this.ret === other.ret }
     // Finally compare types of their returns
     return this.ret.equals(other.ret)
+  }
+
+  isIntrinsicShim(): boolean {
+    return (this.shimFor !== null)
+  }
+  setShimForInstrinsic(instrinsicMethod: Function) {
+    this.shimFor = instrinsicMethod
   }
 }
 

--- a/src/typesystem/bootstrap.ts
+++ b/src/typesystem/bootstrap.ts
@@ -63,7 +63,7 @@ module.exports = function (TypeSystem) {
     module.setTypeOfProperty(methodName, moduleMethod)
     var instanceMethod = new types.Function(this.rootObject, [], returnType)
     instanceMethod.isInstanceMethod = true
-    instanceMethod.shimFor          = moduleMethod
+    instanceMethod.setShimForInstrinsic(moduleMethod)
     receiverType.setTypeOfProperty(methodName, instanceMethod)
   }
 


### PR DESCRIPTION
Move intrinsics checks onto methods themselves instead of receivers. This allows extending of intrinsic-backed types (ie. strings, integers, etc.).