### PR TITLE
Grammar refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/dirk/hummingbird",
   "dependencies": {
     "pegjs": "~0.8.0",
+    "jison": "~0.4.15",
     "optimist": "~0.6.1",
     "xregexp": "~2.0.0",
     "llvm2": "0.2.13",
@@ -26,7 +27,8 @@
     "coveralls": "~2.11.2",
     "glob": "~5.0.5",
     "chokidar": "~1.0.1",
-    "chalk": "~1.0.0"
+    "chalk": "~1.0.0",
+    "prettyjson": "~1.1.2"
   },
   "scripts": {
     "grammar": "node_modules/.bin/pegjs --cache src/grammar.pegjs",

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -42,6 +42,10 @@ export class Node {
   isLastStatement: boolean = false
 
   print() { out.write(inspect(this)) }
+  dump() {
+    var name = this.constructor['name']
+    throw new Error('Dumping node yet implemented for node: '+name)
+  }
   compile(...rest) {
     throw new Error('Compilation not yet implemented for node: '+this.constructor['name'])
   }
@@ -515,11 +519,17 @@ export class New extends Node {
 }
 
 
+type Pathable = Call|Identifier|Indexer
+
 export class Identifier extends Node {
   name:   string
-  parent: Node
-  child:  Node
-  type:   any
+  parent: Pathable
+  child:  Pathable
+  // The initial type
+  initialType: any
+  // Ultimate type (either the initial if no children or the ultimate type
+  // if it has children)
+  type: any
 
   constructor(name) {
     super()
@@ -555,11 +565,10 @@ export class Identifier extends Node {
   }
 }
 
-
 export class Call extends Node {
   args:     any
-  parent:   Node
-  child:    Node
+  parent:   Pathable
+  child:    Pathable
   type:     any
   baseType: any
 
@@ -600,8 +609,8 @@ export class Call extends Node {
 
 export class Indexer extends Node {
   expr:   any
-  parent: Node
-  child:  Node
+  parent: Pathable
+  child:  Pathable
   type:   any
 
   constructor(expr) {

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -145,7 +145,7 @@ assgop = "="
 // Path assignment of existing variables and their indexes/properties
 leftpath     = n:identifier path:(leftproperty)* { return p.parseLeft(n, path) }
 leftindexer  = "[" _ e:expr _ "]" { return pos(p.parseLeftIndexer(e)) }
-leftproperty = "." n:name { return pos(p.parseLeftProperty(n)) }
+leftproperty = "." i:identifier { return pos(p.parseLeftProperty(i)) }
 
 multistmt = "multi" whitespace n:name _ a:args _ r:ret? { return pos(p.parseMutli(n, a, r)) }
 

--- a/src/grammar.pegjs
+++ b/src/grammar.pegjs
@@ -49,7 +49,7 @@
   p.parseReturn = function (expr) { return [expr] }
 
   p.parseExpr = function (expr) { return ['expr', expr] }
-  p.parseCallExpr = function (call) { return ['callexpr', call] }
+  p.parseCallExpr = function (args) { return ['callexpr', args] }
   p.parseCallArgs = function (args) { return ['callargs'].concat(args) }
   p.parseIndexer = function (base, indexer) { return [base, indexer] }
   p.parseIdentifier = function (name) { return name }
@@ -67,7 +67,12 @@
   p.parseMutli = function (name, args, ret) { return [name, args, ret] }
 
   if (typeof require !== 'undefined') {
-    // require('./parser-extension')(p)
+    for (key in p) {
+      if (p.hasOwnProperty(key)) {
+        delete p[key]
+      }
+    }
+    require('./parser-extension')(p)
   }
 }// End preamble
 
@@ -138,7 +143,7 @@ assgop = "="
        / "+="
 
 // Path assignment of existing variables and their indexes/properties
-leftpath     = n:name path:(leftproperty)* { return p.parseLeft(n, path) }
+leftpath     = n:identifier path:(leftproperty)* { return p.parseLeft(n, path) }
 leftindexer  = "[" _ e:expr _ "]" { return pos(p.parseLeftIndexer(e)) }
 leftproperty = "." n:name { return pos(p.parseLeftProperty(n)) }
 
@@ -164,17 +169,17 @@ basicexpr = "(" e:expr ")" { return e }
           / literalexpr
           / pathexpr
 
-pathexpr = i:identifierexpr c:(pathcomponenet)* { return p.parsePathExpr(i, c) }
+pathexpr = i:identifier c:(pathcomponenet)* { return p.parsePathExpr(i, c) }
 
 pathcomponenet = c:callexpr    { return pos(p.parseCallExpr(c)) }
                / pathproperty
                / indexerexpr
 
 callexpr     = "(" _ args:(expr _ ("," _ expr _)* )? _ ")" { return pos(p.parseCallArgs(args ? transformArgs(args) : [])) }
-pathproperty = "." i:identifierexpr { return p.parsePathProperty(i) }
+pathproperty = "." i:identifier { return p.parsePathProperty(i) }
 indexerexpr  = "[" _ e:expr _ "]" { return p.parsePathIndexer(e) }
 
-identifierexpr = n:name { return pos(p.parseIdentifier(n)) }
+identifier = n:name { return pos(p.parseIdentifier(n)) }
 
 // chainexpr = n:name t:(indexer / property / call)* { return pos(p.parseChain(n, t)) }
 

--- a/src/parser-extension.js
+++ b/src/parser-extension.js
@@ -47,6 +47,10 @@ module.exports = function (p) {
     return new AST.Root(statements)
   }
 
+  p.parseExpr = function (expr) {
+    return expr
+  }
+
   p.parseBinary = function (left, op, right) {
     return new AST.Binary(left, op, right)
   }
@@ -88,20 +92,26 @@ module.exports = function (p) {
     return new AST.While(cond, block)
   }
 
-  // p.parseChain = function (name, tail) {
-  //   return new AST.Chain(name, tail)
-  // }
-
   p.parseAssignment = function (path, op, expr) {
     return new AST.Assignment('path', path, op, expr)
+  }
+
+  p.parseLeft = function (name, path) {
+    return AST.constructPath(name, path)
   }
 
   p.parseReturn = function (expr) {
     return new AST.Return(expr)
   }
 
-  p.parseCall = function (base, call) {
-    return new AST.Call(base, call)
+
+
+  p.parseCallExpr = function (args) {
+    return new AST.Call(args)
+  }
+
+  p.parseCallArgs = function (args) {
+    return args
   }
 
   p.parseProperty = function (base, property) {
@@ -112,13 +122,18 @@ module.exports = function (p) {
     return new AST.Identifier(name)
   }
 
-  p.parsePath = function (name, path) {
-    return new AST.Path(name, path)
+  p.parsePathExpr = function (name, path) {
+    return AST.constructPath(name, path)
   }
 
   p.parsePathProperty = function (name) {
-    return new AST.Identifier(name)
+    return name
   }
+
+  p.parsePathIndexer = function (expr) {
+    return new AST.Indexer(expr)
+  }
+
 
   p.parseFunctionType = function (args, ret) {
     // Turn null args into a proper empty array of arguments

--- a/src/parser-extension.js
+++ b/src/parser-extension.js
@@ -100,6 +100,10 @@ module.exports = function (p) {
     return AST.constructPath(name, path)
   }
 
+  p.parseLeftProperty = function (identifier) {
+    return identifier
+  }
+
   p.parseReturn = function (expr) {
     return new AST.Return(expr)
   }
@@ -126,8 +130,8 @@ module.exports = function (p) {
     return AST.constructPath(name, path)
   }
 
-  p.parsePathProperty = function (name) {
-    return name
+  p.parsePathProperty = function (identifier) {
+    return identifier
   }
 
   p.parsePathIndexer = function (expr) {

--- a/src/targets/javascript.ts
+++ b/src/targets/javascript.ts
@@ -226,7 +226,7 @@ export class JSCompiler {
       var ExpressionStatements: any[] = [
         AST.Function,
         AST.New,
-        AST.Property
+        AST.Identifier
       ];
       if (ExpressionStatements.indexOf(stmt.constructor) !== -1) {
         return this.compileExpression(stmt, opts)
@@ -242,8 +242,6 @@ export class JSCompiler {
       return this.compileLiteral(<AST.Literal>expr, opts)
     case AST.Function:
       return this.compileFunction(<AST.Function>expr, opts)
-    case AST.Property:
-      return this.compileProperty(<AST.Property>expr, opts)
     case AST.Call:
       return this.compileCall(<AST.Call>expr, opts)
     case AST.Identifier:
@@ -335,25 +333,13 @@ export class JSCompiler {
     return asSourceNode(bin, ret)
   }
 
-  compileProperty(prop: AST.Property, opts: CompileOptions) {
-    var term = ";\n"
-    if (opts && opts.omitTerminator === true) { term = '' }
-
-    var property = prop.property
-    if (typeof property !== 'string') {
-      property = this.compileExpression(prop.property, {omitTerminator: true})
-    }
-    var base = this.compileIdentifier(prop.base, {omitTerminator: true})
-    var ret = [base, '.' , property, term]
-    return asSourceNode(prop, ret)
-  }// compileProperty
-
   compileCall(call: AST.Call, opts: CompileOptions) {
     var self = this
     var args = call.args.map(function (arg) {
       return self.compileExpression(arg, {omitTerminator: true})
     })
-    var ret = [this.compileExpression(call.base), '(']
+    var ret = ['(']
+
     var length = args.length, lastIndex = args.length - 1
     for (var i = 0; i < length; i++) {
       ret.push(args[i])
@@ -362,7 +348,13 @@ export class JSCompiler {
       }
     }
     ret.push(')')
+
+    if (call.child) {
+      this.compileChild(call.child, opts)
+    }
+
     if (!opts || opts.omitTerminator !== true) { ret.push(";\n") }
+
     return asSourceNode(call, ret)
   }// compileCall
 
@@ -425,18 +417,33 @@ export class JSCompiler {
     } else {
       // TODO: Handle more complex path assignments
       // throw new Error('Compilation of path-assignments not yet implemented')
-      var lvalue = assg.lvalue.name
-      assg.lvalue.path.forEach(function (item) {
-        lvalue += '.'+self.compileIdentifier(item, opts)
-      })
+      var lvalue = this.compileExpression(assg.lvalue, {omitTerminator: true})
       var rvalue = this.compileExpression(assg.rvalue, {omitTerminator: true})
       ret = [lvalue, ' '+assg.op+' ', rvalue, term]
     }
     return asSourceNode(assg, ret)
   }// compileAssignment
 
+  compileChild(node: AST.Node, opts: CompileOptions) {
+    switch (node.constructor) {
+    case AST.Identifier:
+      return this.compileIdentifier(<AST.Identifier>node, opts)
+    case AST.Call:
+      return this.compileCall(<AST.Call>node, opts)
+    default:
+      throw new TypeError('Child compilation fall-through on: '+node.constructor['name'])
+    }
+  }
+
   compileIdentifier(id: AST.Identifier, opts: CompileOptions) {
-    return asSourceNode(id, id.name)
+    var ret: any[] = [id.name]
+    if (id.parent) {
+      ret.unshift('.')
+    }
+    if (id.child) {
+      ret.push(this.compileChild(id.child, opts))
+    }
+    return asSourceNode(id, ret)
   }
 
   compileLiteral(literal: AST.Literal, opts: CompileOptions) {

--- a/src/targets/javascript.ts
+++ b/src/targets/javascript.ts
@@ -338,7 +338,7 @@ export class JSCompiler {
     var args = call.args.map(function (arg) {
       return self.compileExpression(arg, {omitTerminator: true})
     })
-    var ret = ['(']
+    var ret: any[] = ['(']
 
     var length = args.length, lastIndex = args.length - 1
     for (var i = 0; i < length; i++) {
@@ -350,7 +350,7 @@ export class JSCompiler {
     ret.push(')')
 
     if (call.child) {
-      this.compileChild(call.child, opts)
+      ret.push(this.compileChild(call.child, opts))
     }
 
     if (!opts || opts.omitTerminator !== true) { ret.push(";\n") }
@@ -408,7 +408,7 @@ export class JSCompiler {
     if (assg.type === 'var' || assg.type === 'let') {
       // TODO: Register name in context scope and check for conflicts.
       var lvalue = assg.lvalue.name
-      if (assg.rvalue !== false) {
+      if (assg.rvalue) {
         var rvalue = this.compileExpression(assg.rvalue, {omitTerminator: true})
         ret = ['var ', lvalue, ' '+assg.op+' ', rvalue, term]
       } else {
@@ -417,9 +417,9 @@ export class JSCompiler {
     } else {
       // TODO: Handle more complex path assignments
       // throw new Error('Compilation of path-assignments not yet implemented')
-      var lvalue = this.compileExpression(assg.lvalue, {omitTerminator: true})
-      var rvalue = this.compileExpression(assg.rvalue, {omitTerminator: true})
-      ret = [lvalue, ' '+assg.op+' ', rvalue, term]
+      var compiledLvalue = this.compileExpression(assg.lvalue, {omitTerminator: true}),
+          compiledRvalue = this.compileExpression(assg.rvalue, {omitTerminator: true})
+      ret = [compiledLvalue, ' '+assg.op+' ', compiledRvalue, term]
     }
     return asSourceNode(assg, ret)
   }// compileAssignment

--- a/src/types.ts
+++ b/src/types.ts
@@ -310,6 +310,9 @@ export class Function extends Type {
   setShimForInstrinsic(instrinsicMethod: Function) {
     this.shimFor = instrinsicMethod
   }
+  getIntrinsicShim(): Function {
+    return this.shimFor
+  }
 }
 
 

--- a/src/typesystem.ts
+++ b/src/typesystem.ts
@@ -556,7 +556,7 @@ TypeSystem.prototype.visitPath = function (node: AST.Assignment, scope) {
   this.visitIdentifier(base, scope)
 
   var current = base.child
-  while (current) {
+  while (true) {
     if (current instanceof AST.Call) {
       throw new TypeError("Can't have Call in path assignment", current)
     }
@@ -572,11 +572,20 @@ TypeSystem.prototype.visitPath = function (node: AST.Assignment, scope) {
         throw new TypeError('Trying to path assign to read-only property', current)
       }
     }
+    if (!current.child) { break }
+
     current = current.child
   }
 
   // TODO: Check that there are no calls in this path and for any other
   //       things that may make the path-assignment impossible
+
+  var lvalueType = current.type,
+      rvalueType = this.resolveExpression(node.rvalue, scope)
+
+  if (!lvalueType.equals(rvalueType)) {
+    throw new TypeError('Unequal types in assignment: '+lvalueType.inspect()+' </> '+rvalueType.inspect(), node)
+  }
 }
 
 TypeSystem.prototype.resolveType = function (node, scope) {

--- a/src/typesystem.ts
+++ b/src/typesystem.ts
@@ -555,26 +555,32 @@ TypeSystem.prototype.visitPath = function (node: AST.Assignment, scope) {
 
   this.visitIdentifier(base, scope)
 
-  var current = base.child
-  while (true) {
-    if (current instanceof AST.Call) {
-      throw new TypeError("Can't have Call in path assignment", current)
-    }
-    if (current instanceof AST.Identifier) {
-      var parent       = current.parent,
-          parentType   = parent.getInitialType(),
-          propertyName = current.name
-
-      assertInstanceOf(parentType, types.Instance)
-      parentType = parentType.type
-
-      if (parentType.hasPropertyFlag(propertyName, types.Flags.ReadOnly)) {
-        throw new TypeError('Trying to path assign to read-only property', current)
+  var current = null
+  if (base.child) {
+    current = base.child
+    while (true) {
+      if (current instanceof AST.Call) {
+        throw new TypeError("Can't have Call in path assignment", current)
       }
-    }
-    if (!current.child) { break }
+      if (current instanceof AST.Identifier) {
+        var parent       = current.parent,
+            parentType   = parent.getInitialType(),
+            propertyName = current.name
 
-    current = current.child
+        assertInstanceOf(parentType, types.Instance)
+        parentType = parentType.type
+
+        if (parentType.hasPropertyFlag(propertyName, types.Flags.ReadOnly)) {
+          throw new TypeError('Trying to path assign to read-only property', current)
+        }
+      }
+      if (!current.child) { break }
+
+      current = current.child
+    }
+
+  } else {
+    current = base
   }
 
   // TODO: Check that there are no calls in this path and for any other

--- a/src/typesystem.ts
+++ b/src/typesystem.ts
@@ -1056,6 +1056,10 @@ TypeSystem.prototype.visitCall = function (node: AST.Call, scope) {
     }
   }
   node.type = new types.Instance(functionType.ret)
+
+  if (node.child) {
+    this.visitChild(node, node.child, scope)
+  }
 }
 
 /*

--- a/src/typesystem.ts
+++ b/src/typesystem.ts
@@ -53,7 +53,7 @@ class TypeSystem {
   visitPath:              (node: AST.Assignment, scope: scope.Scope) => void
   visitLet:               (node: AST.Assignment, scope: scope.Scope) => void
   visitVar:               (node: AST.Assignment, scope: scope.Scope) => void
-  visitExpression:        (node: AST.Node,      scope: scope.Scope, immediate: any) => void
+  visitExpression:        (node: AST.Node,       scope: scope.Scope, immediate: any) => void
   visitLiteral:           (node: AST.Literal,    scope: scope.Scope) => void
   visitNew:               (node: AST.New,        scope: scope.Scope) => void
   visitBinary:            (node: AST.Binary,     scope: scope.Scope) => void
@@ -63,8 +63,8 @@ class TypeSystem {
   visitNamedFunction:     (node: AST.Function,   scope: scope.Scope) => void
   visitFunctionStatement: (node: AST.Function,   scope: scope.Scope, searchInParent: Function) => void
   visitIdentifier:        (node: AST.Identifier, scope: scope.Scope) => void
-  visitProperty:          (node: AST.Property,   scope: scope.Scope, parentNode: AST.Node) => void
   visitCall:              (node: AST.Call,       scope: scope.Scope) => void
+  visitChild:             (node: AST.Node, child: AST.Node, scope: scope.Scope) => void
   // visitChain:          (node, scope) => void
 }
 // Add the bootstrap methods to the TypeSystem
@@ -157,10 +157,12 @@ TypeSystem.prototype.visitStatement = function (node, scope, parentNode) {
         this.visitLet(node, scope)
       } else if (node.lvalue instanceof AST.Var) {
         this.visitVar(node, scope)
-      } else if (node.lvalue instanceof AST.Path) {
+      } else if (node.lvalue instanceof AST.Identifier) {
         this.visitPath(node, scope)
       } else {
-        throw new TypeError('Cannot visit Assignment with: '+node.lvalue+' ('+node.lvalue.constructor.name+')')
+        var lvalue = node.lvalue,
+            name   = lvalue.constructor.name
+        throw new TypeError('Cannot visit Assignment with: '+lvalue+' ('+name+')', node)
       }
       break
     case AST.If:
@@ -182,9 +184,9 @@ TypeSystem.prototype.visitStatement = function (node, scope, parentNode) {
         throw new TypeError('Cannot visit non-statement binary: '+node.op)
       }
       break
-    // case AST.Chain:
-    //   this.visitChain(node, scope)
-    //   break
+    case AST.Identifier:
+      this.visitIdentifier(node, scope)
+      break
     case AST.Multi:
       this.visitMulti(node, scope)
       break
@@ -542,43 +544,13 @@ TypeSystem.prototype.visitReturn = function (node: AST.Return, scope, parentNode
 }
 
 TypeSystem.prototype.visitPath = function (node, scope) {
-  var path = node.lvalue
-  var foundScope = scope.findScopeForName(path.name)
-  if (foundScope === null) {
-    throw new TypeError('Failed to find '+path.name)
-  }
-  var lvalueType = foundScope.get(path.name)
-  // Now revise that type according to the path
-  path.path.forEach(function (item) {
-    switch (item.constructor) {
-      case AST.Identifier:
-        if (!(lvalueType instanceof types.Instance)) {
-          throw new TypeError('Cannot get property of non-Instance', item)
-        }
-        var propertyName = item.name
-        // Unbox the lvalue instance
-        var instance = lvalueType,
-            type     = instance.type
-        // Finally look up the type of the property and box it up
-        var newType = type.getTypeOfProperty(propertyName, item)
-        lvalueType = new types.Instance(newType)
-        // Also check the flags to make sure we're not trying to write to
-        // a read-only property
-        if (type.hasPropertyFlag(propertyName, types.Flags.ReadOnly)) {
-          throw new TypeError('Trying to assign to read-only property: '+propertyName, node)
-        }
-        // Set the type that is going to be returned at this stage on the item
-        item.type = lvalueType
-        break
-      default:
-        throw new TypeError('Cannot handle item in path of type: '+item.constructor.name, node)
-    }
-  })
+  var base = node.lvalue
+  assertInstanceOf(base, AST.Identifier, 'Path assignment must begin with an Identifier')
 
-  var rvalueType = this.resolveExpression(node.rvalue, scope)
-  if (!lvalueType.equals(rvalueType)) {
-    throw new TypeError('Unequal types in assignment: '+lvalueType.inspect()+' </> '+rvalueType.inspect(), node)
-  }
+  this.visitIdentifier(base, scope)
+
+  // TODO: Check that there are no calls in this path and for any other
+  //       things that may make the path-assignment impossible
 }
 
 TypeSystem.prototype.resolveType = function (node, scope) {
@@ -692,12 +664,6 @@ TypeSystem.prototype.visitExpression = function (node, scope, immediate) {
       break
     case AST.Identifier:
       this.visitIdentifier(node, scope)
-      break
-    case AST.Property:
-      this.visitProperty(node, scope)
-      break
-    case AST.Call:
-      this.visitCall(node, scope)
       break
     default:
       throw new Error("Can't visit expression: "+node.constructor['name'])
@@ -855,7 +821,13 @@ TypeSystem.prototype.visitFunction = function (node: AST.Function, parentScope, 
   if (type.ret) {
     returnTypes.forEach(function (returnType) {
       if (!type.ret.equals(returnType)) {
-        throw new TypeError('Type returned by function does not match declared return type')
+        var expected = type.ret.inspect(),
+            got      = returnType.inspect()
+
+        var message = "Type returned by function does not match declared return type"
+        message += ` (expected ${expected}, got ${got})`
+
+        throw new TypeError(message)
       }
     })
     return
@@ -973,51 +945,67 @@ var know = function (node, type) {
   return type
 }
 
+TypeSystem.prototype.visitChild = function (node: AST.Node, child: AST.Node, scope) {
+  switch (child.constructor) {
+    case AST.Identifier:
+      this.visitIdentifier(child, scope)
+      break
+    case AST.Call:
+      this.visitCall(child, scope)
+      break
+    case AST.Indexer:
+      this.visitIndexer(child, scope)
+      break
+    default:
+      throw new TypeError("Can't visit child: "+node.constructor['name'])
+  }
+}
+
 TypeSystem.prototype.visitIdentifier = function (node: AST.Identifier, scope) {
   if (node.parent) {
+    var parentType = node.parent.type
+    node.type = 
     // throw new TypeError("Identifier cannot have a parent", node)
-    node.type = this.getTypeOfTypesProperty(node.parent.baseType, node.name)
+    node.type = this.getTypeOfTypesProperty(parentType, node.name)
   } else {
     node.type = scope.get(node.name)
   }
-}
 
-TypeSystem.prototype.visitProperty = function (node: AST.Property, scope, parentNode) {
-  // Set up the parents
-  if (node.parent) {
-    node.base.parent = node.parent
+  // Don't need to do anything more if there's not a child
+  if (!node.child) { return }
+
+  var child = node.child
+  this.visitChild(node, child, scope)
+
+  // Now compute the ultimate type
+  node.initialType = node.type
+  // Descend down the chain
+  while (true) {
+    if (child.child) {
+      child = child.child
+    } else {
+      break
+    }
   }
-  node.property.parent = node
-
-  // Then visit the base and the child
-  this.visitExpression(node.base, scope)
-  node.baseType = node.base.type
-
-  if (typeof node.property === 'string') {
-    throw new Error('Unreachable')
-    // If it's just basic string then look up the property on ourselves
-    var propertyType = this.getTypeOfTypesProperty(node.baseType, node.property)
-    node.type = propertyType
-
-  } else {
-    // Otherwise visit the property as a full expression
-    this.visitExpression(node.property, scope)
-    // Update from the child's type
-    node.type = node.property.type
+  if (!child || !child.type) {
+    throw new TypeError('Missing child type for ultimate root Identifier type')
   }
+  node.type = child.type
 }
 
 TypeSystem.prototype.visitCall = function (node: AST.Call, scope) {
-  // Make our base identifier point to our parent so it will resolve correctly
-  // when we visit it
-  // node.base.parent = node.parent
-  node.base.parent = node.parent
-  this.visitExpression(node.base, scope)
-  node.baseType = node.base.type
+  if (!node.parent) {
+    throw new TypeError("Call must have parent")
+  }
 
-  assertInstanceOf(node.baseType, types.Instance, 'Expected Instance for base type of Call')
-  var functionType = node.baseType.type
-  assertInstanceOf(functionType, types.Function, 'Expected Function for unboxed type')
+  var parent = node.parent,
+      parentType = parent.type
+
+  // Must be calling an instance
+  assertInstanceOf(parentType, types.Instance, 'Expected Instance for function of Call')
+  // Unbox and check that it is a function
+  var functionType = parentType.type
+  assertInstanceOf(functionType, types.Function, 'Expected Function for unboxed function of Call')
 
   var args     = node.args,
       typeArgs = functionType.args

--- a/test-grammar.js
+++ b/test-grammar.js
@@ -1,4 +1,5 @@
 var util       = require('util'),
+    fs         = require('fs'),
     prettyjson = require('prettyjson'),
     inlineSourceMapComment = require('inline-source-map-comment')
 
@@ -6,10 +7,11 @@ require('source-map-support').install()
 
 var grammar = require('./src/grammar')
 
-var source = "a(b)[c].d[e](f)"
+// var source = "a(b)[c].d[e](f)"
+var source = fs.readFileSync('examples/classes.hb').toString()
 
 var tree = grammar.parse(source, {})
 
 // console.log(prettyjson.render(tree, {}))
 
-tree.print()
+tree.dump()

--- a/test-grammar.js
+++ b/test-grammar.js
@@ -1,5 +1,8 @@
 var util       = require('util'),
-    prettyjson = require('prettyjson')
+    prettyjson = require('prettyjson'),
+    inlineSourceMapComment = require('inline-source-map-comment')
+
+require('source-map-support').install()
 
 var grammar = require('./src/grammar')
 
@@ -7,4 +10,6 @@ var source = "a(b)[c].d[e](f)"
 
 var tree = grammar.parse(source, {})
 
-console.log(prettyjson.render(tree, {}))
+// console.log(prettyjson.render(tree, {}))
+
+tree.print()

--- a/test-grammar.js
+++ b/test-grammar.js
@@ -14,4 +14,10 @@ var tree = grammar.parse(source, {})
 
 // console.log(prettyjson.render(tree, {}))
 
+var TypeSystem = require('./src/typesystem').TypeSystem
+
 tree.dump()
+
+var typesystem = new TypeSystem()
+typesystem.walk(tree, 'unknown.hb')
+

--- a/test-grammar.js
+++ b/test-grammar.js
@@ -1,0 +1,10 @@
+var util       = require('util'),
+    prettyjson = require('prettyjson')
+
+var grammar = require('./src/grammar')
+
+var source = "a(b)[c].d[e](f)"
+
+var tree = grammar.parse(source, {})
+
+console.log(prettyjson.render(tree, {}))


### PR DESCRIPTION
For better processing of path expressions:

```js
a(b)[c].d[e](f)
```