### PR TITLE
Add a REPL

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,10 +15,18 @@ mod vm;
 
 fn main() {
     let args: Vec<String> = env::args().collect();
-    if args.len() < 2 || args.len() > 2 {
-        println!("Usage: hummingbird [file]");
+    if args.len() < 1 || args.len() > 2 {
+        println!("Usage: hummingbird [file]?");
         exit(-1);
     }
-    let filename = &args[1];
-    vm::Vm::run_file(filename);
+    match args.len() {
+        1 => {
+            vm::Vm::run_repl();
+        }
+        2 => {
+            let filename = &args[1];
+            vm::Vm::run_file(filename);
+        }
+        _ => unreachable!(),
+    }
 }

--- a/src/vm/errors.rs
+++ b/src/vm/errors.rs
@@ -1,6 +1,36 @@
 use std::error;
 use std::fmt::{Display, Error, Formatter};
 
+use super::vm::StackSnapshot;
+
+#[derive(Debug)]
+pub struct AnnotatedError {
+    wrapped: Box<dyn error::Error>,
+    stack: StackSnapshot,
+}
+
+impl AnnotatedError {
+    pub fn new(wrapped: Box<dyn error::Error>, stack: StackSnapshot) -> Self {
+        Self { wrapped, stack }
+    }
+
+    pub fn get_wrapped(&self) -> &Box<dyn error::Error> {
+        &self.wrapped
+    }
+}
+
+impl Display for AnnotatedError {
+    fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
+        write!(f, "{}", self.wrapped)?;
+        for (index, description) in self.stack.iter() {
+            write!(f, "\n  {}: {}", index, description)?;
+        }
+        Ok(())
+    }
+}
+
+impl error::Error for AnnotatedError {}
+
 #[derive(Debug)]
 pub struct UndefinedNameError {
     name: String,

--- a/src/vm/frame.rs
+++ b/src/vm/frame.rs
@@ -146,7 +146,7 @@ impl FrameApi for Frame {
         }
     }
 
-    fn can_catch_error(&mut self, error: &Box<dyn error::Error>) -> bool {
+    fn can_catch_error(&self, error: &Box<dyn error::Error>) -> bool {
         match self {
             Frame::Bytecode(frame) => frame.can_catch_error(error),
             Frame::Module(frame) => frame.can_catch_error(error),
@@ -180,8 +180,17 @@ pub trait FrameApi {
     /// When an error is raised the VM will call this on each frame of the
     /// stack. If the frame returns false it will be unwound off the stack.
     /// It it returns true then it must be able to immediately receive a call
-    /// to `receive_error`.
-    fn can_catch_error(&mut self, _error: &Box<dyn error::Error>) -> bool {
+    /// to `catch_error`. In pseudocode the VM's execution looks like:
+    ///
+    ///   loop {
+    ///     if stack.top.can_catch_error(error) {
+    ///       stack.catch_error(error)
+    ///       break
+    ///     }
+    ///     stack.pop()
+    ///   }
+    ///
+    fn can_catch_error(&self, _error: &Box<dyn error::Error>) -> bool {
         false
     }
 
@@ -606,7 +615,7 @@ impl FrameApi for ReplFrame {
     }
 
     /// The top-level REPL frame can always catch any errors that bubble up.
-    fn can_catch_error(&mut self, _error: &Box<dyn error::Error>) -> bool {
+    fn can_catch_error(&self, _error: &Box<dyn error::Error>) -> bool {
         true
     }
 

--- a/src/vm/loader.rs
+++ b/src/vm/loader.rs
@@ -30,8 +30,9 @@ fn read_and_parse_file<P: AsRef<Path>>(path: P) -> Result<ast::Module, Box<dyn E
 pub fn compile_ast_into_module(
     ast_module: &ast::Module,
     name: String,
+    ast_flags: ast_to_ir::CompilationFlags,
 ) -> Result<LoadedModule, Box<dyn Error>> {
-    let ir_module = ast_to_ir::compile(ast_module);
+    let ir_module = ast_to_ir::compile(ast_module, ast_flags);
     if *DEBUG_IR {
         println!("IR({}):", name);
         ir::printer::Printer::new(std::io::stdout()).print_module(&ir_module)?;
@@ -72,7 +73,7 @@ pub fn load_file<P: AsRef<Path>>(path: P) -> Result<LoadedModule, Box<dyn Error>
         println!();
     }
 
-    compile_ast_into_module(&ast_module, name)
+    compile_ast_into_module(&ast_module, name, Default::default())
 }
 
 pub struct InnerLoadedModule {

--- a/src/vm/loader.rs
+++ b/src/vm/loader.rs
@@ -27,7 +27,7 @@ fn read_and_parse_file<P: AsRef<Path>>(path: P) -> Result<ast::Module, Box<dyn E
     Ok(parser::parse(source))
 }
 
-fn compile_ast_into_module(
+pub fn compile_ast_into_module(
     ast_module: &ast::Module,
     name: String,
 ) -> Result<LoadedModule, Box<dyn Error>> {
@@ -126,6 +126,11 @@ impl LoadedModule {
 
     pub fn static_closure(&self) -> Closure {
         self.0.borrow().static_closure.clone()
+    }
+
+    /// Should only be called by the REPL!
+    pub fn override_static_closure(&self, static_closure: Closure) {
+        self.0.borrow_mut().static_closure = static_closure;
     }
 
     pub fn function(&self, id: u16) -> LoadedFunction {

--- a/src/vm/loader.rs
+++ b/src/vm/loader.rs
@@ -235,6 +235,18 @@ impl LoadedFunction {
         self.0.id
     }
 
+    /// Returns a string indicating the base-name of the module it was defined
+    /// in and its own name.
+    pub fn qualified_name(&self) -> String {
+        let module_basename = Path::new(&self.module().name())
+            .file_name()
+            .and_then(|os_str| os_str.to_str())
+            .unwrap_or("(unknown)")
+            .to_owned();
+        let own_name = self.0.bytecode.name();
+        format!("{}:{}", module_basename, own_name)
+    }
+
     pub fn bytecode(&self) -> BytecodeFunction {
         self.0.bytecode.clone()
     }

--- a/src/vm/prelude.rs
+++ b/src/vm/prelude.rs
@@ -17,7 +17,10 @@ pub fn is_in_prelude<N: AsRef<str>>(name: N) -> bool {
 fn prelude_println(arguments: Vec<Value>) -> Value {
     if let Some(argument) = arguments.first() {
         match argument {
+            Value::Boolean(value) => println!("{:?}", value),
+            Value::DynamicFunction(_) => println!("Function"),
             Value::Integer(value) => println!("{}", value),
+            Value::Null => println!("null"),
             _ => unreachable!(),
         }
     };

--- a/src/vm/value.rs
+++ b/src/vm/value.rs
@@ -77,7 +77,10 @@ impl Debug for Value {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
         use Value::*;
         match self {
-            DynamicFunction(_) => write!(f, "DynamicFunction"),
+            DynamicFunction(function) => {
+                let name = function.call_target.function.qualified_name();
+                write!(f, "Function({})", name)
+            }
             Boolean(value) => write!(f, "{:?}", value),
             Integer(value) => write!(f, "{}", value),
             NativeFunction(_) => write!(f, "NativeFunction"),

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -116,7 +116,7 @@ impl Vm {
     fn error_unwind(&mut self, error: Box<dyn error::Error>) -> bool {
         loop {
             let can_catch_error = {
-                let top = match self.stack.last_mut() {
+                let top = match self.stack.last() {
                     Some(frame) => frame,
                     None => {
                         // Out of stack frames to unwind from.


### PR DESCRIPTION
Implements a REPL by compiling a fresh module for every inputted line. The modules are compiled with a special flag to make the main function resolve all variables lexically, and each module has its static closure overwritten to a shared closure. That way all evaluated main functions see the same closure for their variables to be lexically read from/written to.