### PR TITLE
Refactor parsing subsystem

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -6,8 +6,9 @@ mod parser;
 
 pub use self::lexer::Token;
 pub use self::location::{Location, Span};
+pub use self::parser::ParseError;
 
-pub fn parse<I: ToString>(input: I) -> Module {
+pub fn parse<I: ToString>(input: I) -> Result<Module, ParseError> {
     let mut token_stream = lexer::TokenStream::from_string(input.to_string());
-    parser::parse_module(&mut token_stream).unwrap()
+    parser::parse_module(&mut token_stream)
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9,5 +9,5 @@ pub use self::location::{Location, Span};
 
 pub fn parse<I: ToString>(input: I) -> Module {
     let mut token_stream = lexer::TokenStream::from_string(input.to_string());
-    parser::parse_module(&mut token_stream)
+    parser::parse_module(&mut token_stream).unwrap()
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -41,12 +41,10 @@ impl Display for ParseError {
                 got,
                 location,
             } => {
-                write!(
-                    f,
-                    "Unexpected token: got {}, expected {}",
-                    got,
-                    expected.join(" or "),
-                )?;
+                write!(f, "Unexpected token: got {}", got,)?;
+                if !expected.is_empty() {
+                    write!(f, ", expected {}", expected.join(" or "))?;
+                }
                 if let Some(location) = location {
                     write!(f, " at line {} column {}", location.line, location.column)?;
                 }
@@ -178,11 +176,10 @@ fn parse_statement(
     if let Token::Terminal(_) = next {
         return Ok(node);
     }
-    panic_unexpected(
+    Err(ParseError::new_unexpected(
+        vec!["Terminal".to_string()],
         next,
-        Some(vec![Token::Terminal('\n'), Token::Terminal(';')]),
-    );
-    unreachable!()
+    ))
 }
 
 fn try_parse_named_function(input: &mut TokenStream) -> Option<Node> {
@@ -561,10 +558,7 @@ fn parse_atom(input: &mut TokenStream) -> Result<Node, ParseError> {
             input.read();
             Ok(Node::Symbol(SymbolLiteral::new(value)))
         }
-        _ => {
-            panic_unexpected(next, None);
-            unreachable!()
-        }
+        _ => Err(ParseError::new_unexpected(vec![], next)),
     }
 }
 

--- a/src/vm/loader/mod.rs
+++ b/src/vm/loader/mod.rs
@@ -140,7 +140,8 @@ impl Loader {
 
 fn read_and_parse_file<P: AsRef<Path>>(path: P) -> Result<(ast::Module, String), Box<dyn Error>> {
     let source = fs::read_to_string(path)?;
-    Ok((parser::parse(source.clone()), source))
+    let module = parser::parse(source.clone())?;
+    Ok((module, source))
 }
 
 pub fn compile_ast_into_module(

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -88,14 +88,12 @@ impl Vm {
                 let result = match self.loader.load_file_by_name(name, relative_import_path) {
                     Ok(loaded) => Ok(loaded),
                     Err(mut error) => {
-                        println!("Load error!");
                         // Annotate the error with its source. Imports happen
                         // outside of the normal frame fetch-execute loop, so
                         // they instead include the source of the import with
                         // the `Action` so that it can be automatically
                         // embedded in the load error if one occurs.
                         if let Some(source) = source {
-                            println!("Have source!");
                             error.set_source(source);
                         }
                         Err(error)


### PR DESCRIPTION
Refactors the parser to handle errors via `Result`s rather than panicking.