### PR TITLE
Set up multi-stage error type and refactor func bodies

### DIFF
--- a/script/test-end-to-end
+++ b/script/test-end-to-end
@@ -1,2 +1,4 @@
 #!/bin/sh
+# Ensure the latest debug build has been built.
+cargo build
 bundle exec rspec $@

--- a/src/compiler/ir/compile.rs
+++ b/src/compiler/ir/compile.rs
@@ -76,8 +76,6 @@ pub fn compile_modules<'m, M: Iterator<Item = &'m FrontendModule>>(
     let typer = Typer::new(None);
     let root = Root::new(typer.clone());
 
-    // TODO: Build a root `TypeScope` will all the builtins.
-
     for frontend_module in frontend_modules {
         define_module(frontend_module, root.clone());
     }

--- a/src/compiler/ir/compile.rs
+++ b/src/compiler/ir/compile.rs
@@ -232,11 +232,9 @@ impl<'a> Builder<'a> {
     }
 }
 
-fn compile_func_body(builder: &Builder, func_value: FuncValue, body: &ast::FuncBody) {
+fn compile_func_body(builder: &Builder, func_value: FuncValue, body: &ast::Block) {
     builder.append_basic_block(Some("entry"));
-    let implicit_retrn = match body {
-        ast::FuncBody::Block(block) => compile_block(builder, block),
-    };
+    let implicit_retrn = compile_block(builder, body);
     builder.build_return(implicit_retrn);
 }
 

--- a/src/compiler/ir/error.rs
+++ b/src/compiler/ir/error.rs
@@ -1,0 +1,6 @@
+use super::Type;
+
+#[derive(Debug)]
+pub enum IrError {
+    TypeMismatch { expected: Type, got: Type },
+}

--- a/src/compiler/ir/mod.rs
+++ b/src/compiler/ir/mod.rs
@@ -6,14 +6,17 @@ use super::super::type_ast::{self as ast};
 use super::vecs_equal::vecs_equal;
 
 mod compile;
+mod error;
 mod typ;
 mod typer;
 mod value;
 
-pub use compile::{compile_modules, Instruction};
-pub use typ::RealType;
 use typ::*;
 use typer::Typer;
+
+pub use compile::{compile_modules, Instruction};
+pub use error::IrError;
+pub use typ::RealType;
 pub use value::{FuncId, FuncValue, LocalValue, StaticValue, Value, ValueId};
 
 /// A type which:
@@ -121,6 +124,15 @@ impl Container for Module {
 /// AbstractType::UnspecializedFunc -> Func -> FuncValue
 #[derive(Clone)]
 pub struct Func(Rc<InnerFunc>);
+
+impl Func {
+    /// Two `Func`s are equal if and only if they are same `Rc`.
+    pub fn is_equal(&self, other: &Func) -> bool {
+        let self_ptr = &self.0 as *const Rc<InnerFunc>;
+        let other_ptr = &other.0 as *const Rc<InnerFunc>;
+        self_ptr == other_ptr
+    }
+}
 
 struct InnerFunc {
     /// The parent that this func is declared in; should be one of:

--- a/src/compiler/ir/typ.rs
+++ b/src/compiler/ir/typ.rs
@@ -122,9 +122,7 @@ impl std::fmt::Debug for AbstractType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         use AbstractType::*;
         match self {
-            UnspecializedFunc(func) => {
-                write!(f, "UnspecializedFunc({})", func.name())
-            }
+            UnspecializedFunc(func) => write!(f, "UnspecializedFunc({})", func.name()),
         }
     }
 }

--- a/src/compiler/ir/typ.rs
+++ b/src/compiler/ir/typ.rs
@@ -2,7 +2,7 @@ use super::super::super::type_ast::{self as ast};
 use super::super::vecs_equal::vecs_equal;
 use super::Func;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum Type {
     /// A type which can be represented by a value.
     Real(RealType),
@@ -15,6 +15,17 @@ impl Type {
         match self {
             Real(real_type) => real_type,
             _ => panic!("Cannot convert to Real type"),
+        }
+    }
+
+    pub fn is_equal(&self, other: &Type) -> bool {
+        use Type::*;
+        match (self, other) {
+            (Real(self_real), Real(other_real)) => self_real.is_equal(other_real),
+            (Abstract(self_abstract), Abstract(other_abstract)) => {
+                self_abstract.is_equal(other_abstract)
+            }
+            _ => false,
         }
     }
 }
@@ -93,4 +104,27 @@ impl TupleType {
 #[derive(Clone)]
 pub enum AbstractType {
     UnspecializedFunc(Func),
+}
+
+impl AbstractType {
+    pub fn is_equal(&self, other: &AbstractType) -> bool {
+        use AbstractType::*;
+        match (self, other) {
+            (
+                UnspecializedFunc(self_unspecialized_func),
+                UnspecializedFunc(other_unspecialized_func),
+            ) => self_unspecialized_func.is_equal(other_unspecialized_func),
+        }
+    }
+}
+
+impl std::fmt::Debug for AbstractType {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        use AbstractType::*;
+        match self {
+            UnspecializedFunc(func) => {
+                write!(f, "UnspecializedFunc({})", func.name())
+            }
+        }
+    }
 }

--- a/src/compiler/ir/typer.rs
+++ b/src/compiler/ir/typer.rs
@@ -100,7 +100,7 @@ impl Typer {
                     });
                 }
                 // If they're equal then we don't need to re-save.
-                return Ok(())
+                return Ok(());
             }
         }
         let mut types = self.0.types.borrow_mut();

--- a/src/compiler/ir/value.rs
+++ b/src/compiler/ir/value.rs
@@ -161,13 +161,17 @@ impl FuncValue {
         let mut parameter_pairs = vec![];
         for (index, parameter) in parameters.into_iter().enumerate() {
             let ast_argument = &ast_func.arguments[index];
-            typer.set_type(&ast_argument.typ, Type::Real(parameter.clone()));
+            typer
+                .set_type(&ast_argument.typ, Type::Real(parameter.clone()))
+                .expect("Parameter type mismatch");
             // Also save the names of the parameters so that we can do
             // index resolution when building instructions.
             parameter_pairs.push((ast_argument.name.clone(), parameter));
         }
         let ast_retrn = &ast_func.typ.unwrap_func().retrn.borrow();
-        typer.set_type(ast_retrn, Type::Real(retrn.clone()));
+        typer
+            .set_type(ast_retrn, Type::Real(retrn.clone()))
+            .expect("Return type mismatch");
 
         let mut stack_frame = vec![];
         let scope = ast_func.scope.unwrap_func();

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -3,3 +3,10 @@ mod opaque;
 mod path_to_name;
 pub mod target;
 mod vecs_equal;
+
+use ir::IrError;
+
+enum CompileError {
+    /// Error occurring during the IR sub-stage.
+    Ir(IrError),
+}

--- a/src/parse_ast.rs
+++ b/src/parse_ast.rs
@@ -46,22 +46,8 @@ impl ClosureBody {
 pub struct Func {
     pub name: Word,
     pub arguments: Vec<Word>,
-    pub body: FuncBody,
+    pub body: Block,
     pub span: Span,
-}
-
-#[derive(Clone, Debug, PartialEq)]
-pub enum FuncBody {
-    Block(Block),
-}
-
-impl FuncBody {
-    pub fn span(&self) -> Span {
-        use FuncBody::*;
-        match self {
-            Block(block) => block.span.clone(),
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -354,12 +354,12 @@ fn expect_func(input: &mut TokenStream) -> ParseResult<Func> {
         }
     }
     expect_to_read!(input, { Token::ParenthesesRight(_) => () });
-    let block = expect_block(input)?;
-    let end = block.span.end.clone();
+    let body = expect_block(input)?;
+    let end = body.span.end.clone();
     Ok(Func {
         name,
         arguments,
-        body: FuncBody::Block(block),
+        body,
         span: Span::new(start, end),
     })
 }
@@ -484,10 +484,10 @@ mod tests {
                         span: Span::new(Location::new(5, 1, 6), Location::new(8, 1, 9),)
                     },
                     arguments: vec![],
-                    body: FuncBody::Block(Block {
+                    body: Block {
                         statements: vec![],
                         span: Span::new(Location::new(11, 1, 12), Location::new(12, 1, 13))
-                    }),
+                    },
                     span: Span::new(Location::new(0, 1, 1), Location::new(12, 1, 13))
                 })]
             })

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,6 +1,8 @@
 use std::fmt::{Debug, Display, Error, Formatter};
+use std::path::PathBuf;
 
 use super::super::parse_ast::*;
+use super::super::StageError;
 use super::lexer::{Token, TokenStream};
 use super::{Location, Span, Word};
 
@@ -412,6 +414,10 @@ impl ParseError {
             got: base_name(&format!("{:?}", got)).to_string(),
             location,
         }
+    }
+
+    pub fn into_stage_error(self, path: &PathBuf, source: &String) -> StageError {
+        StageError::Parse(self, path.clone(), source.clone())
     }
 }
 

--- a/src/type_ast/mod.rs
+++ b/src/type_ast/mod.rs
@@ -6,12 +6,13 @@
 /// remaining in the AST.
 use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
-use super::parse_ast as past;
 use super::parser::{Span, Token, Word};
+use super::{parse_ast as past, StageError};
 
 mod builtins;
 mod nodes;
@@ -162,6 +163,10 @@ impl TypeError {
             wrapped: Box::new(self),
             span,
         }
+    }
+
+    pub fn into_stage_error(self, path: &PathBuf, source: &String) -> StageError {
+        StageError::Type(self, path.clone(), source.clone())
     }
 }
 

--- a/src/type_ast/mod.rs
+++ b/src/type_ast/mod.rs
@@ -208,7 +208,7 @@ mod tests {
     use super::super::parse_ast as past;
     use super::super::parser::{Location, Span, Token, Word};
     use super::scope::{ClosureScope, Scope};
-    use super::{unify, Builtins, Closable, FuncBody, ScopeLike, Type, TypeError, Variable};
+    use super::{unify, Builtins, Closable, ScopeLike, Type, TypeError, Variable};
 
     fn new_scope() -> Scope {
         ClosureScope::new(None).into_scope()

--- a/src/type_ast/nodes.rs
+++ b/src/type_ast/nodes.rs
@@ -80,7 +80,7 @@ impl Closable for ClosureBody {
 pub struct Func {
     pub name: String,
     pub arguments: Vec<FuncArgument>,
-    pub body: FuncBody,
+    pub body: Block,
     // The scope of variables defined within the function.
     pub scope: Scope,
     pub typ: Type,
@@ -114,31 +114,6 @@ impl Closable for Func {
 pub struct FuncArgument {
     pub name: String,
     pub typ: Type,
-}
-
-#[derive(Clone, Debug)]
-pub enum FuncBody {
-    // TODO: Remove this layer of indirection since func bodies must always
-    //   be blocks.
-    Block(Block),
-}
-
-impl FuncBody {
-    pub fn typ(&self) -> Type {
-        use FuncBody::*;
-        match self {
-            Block(block) => block.typ.clone(),
-        }
-    }
-}
-
-impl Closable for FuncBody {
-    fn close(self, tracker: &mut RecursionTracker, scope: Scope) -> TypeResult<FuncBody> {
-        use FuncBody::*;
-        Ok(match self {
-            Block(block) => Block(block.close(tracker, scope)?),
-        })
-    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/type_ast/printer.rs
+++ b/src/type_ast/printer.rs
@@ -95,14 +95,11 @@ impl<O: Write> Printer<O> {
             } else {
                 self.write("]\n")?;
             }
-            // TODO: Body
             self.iwrite("typ: ")?;
             self.write_type(&func.typ, true)?;
             self.write("\n")?;
             self.writeln("body:")?;
-            self.indented(|_| match &func.body {
-                FuncBody::Block(block) => self.print_block(block),
-            })?;
+            self.indented(|_| self.print_block(&func.body))?;
             Ok(())
         })?;
         self.writeln("}")

--- a/src/type_ast/printer.rs
+++ b/src/type_ast/printer.rs
@@ -49,21 +49,21 @@ impl<O: Write> Printer<O> {
         }
     }
 
-    fn indented<F: FnOnce(&Self) -> Result<()>>(&self, inner: F) -> Result<()> {
+    fn indented<F: FnOnce() -> Result<()>>(&self, inner: F) -> Result<()> {
         self.indented_steps(1, inner)
     }
 
-    fn indented_steps<F: FnOnce(&Self) -> Result<()>>(&self, steps: u8, inner: F) -> Result<()> {
+    fn indented_steps<F: FnOnce() -> Result<()>>(&self, steps: u8, inner: F) -> Result<()> {
         let previous = self.indent.take();
         self.indent.set(previous + (2 * steps));
-        let result = inner(self);
+        let result = inner();
         self.indent.set(previous);
         result
     }
 
     pub fn print_module(&self, module: &Module) -> Result<()> {
         self.writeln("Module {")?;
-        self.indented(|this| {
+        self.indented(|| {
             for statement in module.statements.iter() {
                 use ModuleStatement::*;
                 match statement {
@@ -78,12 +78,12 @@ impl<O: Write> Printer<O> {
 
     fn print_func(&self, func: &nodes::Func) -> Result<()> {
         self.writeln("Func {")?;
-        self.indented(|_| {
+        self.indented(|| {
             writeln!(self, "name: {}", func.name)?;
             self.iwrite("arguments: [")?;
             if !func.arguments.is_empty() {
                 self.write("\n")?;
-                self.indented(|_| {
+                self.indented(|| {
                     for argument in func.arguments.iter() {
                         iwrite!(self, "{}: ", argument.name)?;
                         self.write_type(&argument.typ, true)?;
@@ -99,7 +99,7 @@ impl<O: Write> Printer<O> {
             self.write_type(&func.typ, true)?;
             self.write("\n")?;
             self.writeln("body:")?;
-            self.indented(|_| self.print_block(&func.body))?;
+            self.indented(|| self.print_block(&func.body))?;
             Ok(())
         })?;
         self.writeln("}")
@@ -130,10 +130,10 @@ impl<O: Write> Printer<O> {
                 if !arguments.is_empty() {
                     if with_children {
                         for argument in arguments.iter() {
-                            self.indented(|this1| {
-                                this1.lnwrite("")?;
-                                this1.write_recursive_type(argument, true, tracker)?;
-                                this1.write(",")
+                            self.indented(|| {
+                                self.lnwrite("")?;
+                                self.write_recursive_type(argument, true, tracker)?;
+                                self.write(",")
                             })?;
                         }
                         self.lnwrite("): ")?;
@@ -155,7 +155,7 @@ impl<O: Write> Printer<O> {
                 self.write(format!("${}", generic.id))?;
                 if generic.has_constrains() && with_children && !recursive {
                     self.write("(")?;
-                    self.indented(|this| this.write_constraints(&generic.constraints, tracker))?;
+                    self.indented(|| self.write_constraints(&generic.constraints, tracker))?;
                     self.write(")")?;
                 }
                 self.write_pointer(&**outer)
@@ -180,8 +180,8 @@ impl<O: Write> Printer<O> {
                         self.write("G(")?;
                         self.write(format!("{}", generic.id))?;
                         if with_children && !recursive {
-                            self.indented(|this| {
-                                this.write_constraints(&generic.constraints, tracker)
+                            self.indented(|| {
+                                self.write_constraints(&generic.constraints, tracker)
                             })?;
                         }
                         self.write(")")?;
@@ -202,29 +202,29 @@ impl<O: Write> Printer<O> {
             return Ok(());
         }
         self.lnwrite("where")?;
-        self.indented(|this1| {
+        self.indented(|| {
             for constraint in constraints {
                 use GenericConstraint::*;
                 match constraint {
                     Property(property) => {
-                        this1.lnwrite(format!("{}: ", property.name))?;
-                        this1.write_recursive_type(&property.typ, true, tracker)?;
+                        self.lnwrite(format!("{}: ", property.name))?;
+                        self.write_recursive_type(&property.typ, true, tracker)?;
                     }
                     Callable(callable) => {
                         if callable.arguments.is_empty() {
-                            this1.lnwrite("(): ")?;
+                            self.lnwrite("(): ")?;
                         } else {
-                            this1.lnwrite("(\n")?;
+                            self.lnwrite("(\n")?;
                             for argument in callable.arguments.iter() {
-                                this1.indented(|this2| {
-                                    this2.iwrite("")?;
-                                    this2.write_recursive_type(argument, true, tracker)?;
-                                    this2.write(",")
+                                self.indented(|| {
+                                    self.iwrite("")?;
+                                    self.write_recursive_type(argument, true, tracker)?;
+                                    self.write(",")
                                 })?;
                             }
-                            this1.lnwrite("): ")?;
+                            self.lnwrite("): ")?;
                         }
-                        this1.write_recursive_type(&callable.retrn, true, tracker)?;
+                        self.write_recursive_type(&callable.retrn, true, tracker)?;
                     }
                 }
             }
@@ -241,9 +241,9 @@ impl<O: Write> Printer<O> {
         }
         self.write_type(&var.typ, true)?;
         if let Some(initializer) = &var.initializer {
-            self.indented(|this| {
-                this.write(" =")?;
-                this.print_expression(initializer)
+            self.indented(|| {
+                self.write(" =")?;
+                self.print_expression(initializer)
             })?;
         }
         Ok(())
@@ -255,7 +255,7 @@ impl<O: Write> Printer<O> {
             return self.write("}\n");
         }
         self.write("\n")?;
-        self.indented(|_| {
+        self.indented(|| {
             let last_index = block.statements.len().checked_sub(1).unwrap_or(0);
             for statement in block.statements.iter() {
                 use BlockStatement::*;
@@ -286,11 +286,11 @@ impl<O: Write> Printer<O> {
 
     fn print_closure(&self, closure: &Closure) -> Result<()> {
         self.writeln("Closure {")?;
-        self.indented(|_| {
+        self.indented(|| {
             self.iwrite("arguments: [")?;
             if !closure.arguments.is_empty() {
                 self.write("\n")?;
-                self.indented(|_| {
+                self.indented(|| {
                     for argument in closure.arguments.iter() {
                         self.iwrite(format!("{}: ", argument.name))?;
                         self.write_type(&argument.typ, true)?;
@@ -303,7 +303,7 @@ impl<O: Write> Printer<O> {
                 self.write("]\n")?;
             }
             self.writeln("body:")?;
-            self.indented(|_| match &*closure.body {
+            self.indented(|| match &*closure.body {
                 ClosureBody::Block(block) => self.print_block(block),
                 ClosureBody::Expression(expression) => self.print_expression(expression),
             })?;
@@ -316,7 +316,7 @@ impl<O: Write> Printer<O> {
 
     fn print_literal_int(&self, literal: &LiteralInt) -> Result<()> {
         self.writeln("LiteralInt {")?;
-        self.indented(|_| {
+        self.indented(|| {
             writeln!(self, "value: {}", literal.value)?;
             self.iwrite("typ: ")?;
             self.write_type(&literal.typ, false)?;
@@ -327,7 +327,7 @@ impl<O: Write> Printer<O> {
 
     fn print_identifier(&self, identifier: &Identifier) -> Result<()> {
         self.writeln("Identifier {")?;
-        self.indented(|_| {
+        self.indented(|| {
             writeln!(self, "name: {}", identifier.name.name)?;
             self.iwrite("typ: ")?;
             self.write_type(&identifier.typ, true)?;
@@ -338,12 +338,12 @@ impl<O: Write> Printer<O> {
 
     fn print_infix(&self, infix: &Infix) -> Result<()> {
         self.writeln("Infix {")?;
-        self.indented(|_| {
+        self.indented(|| {
             self.writeln("lhs:")?;
-            self.indented(|_| self.print_expression(&infix.lhs))?;
+            self.indented(|| self.print_expression(&infix.lhs))?;
             writeln!(self, "op: {}", infix.op.to_string())?;
             self.writeln("rhs:")?;
-            self.indented(|_| self.print_expression(&infix.rhs))?;
+            self.indented(|| self.print_expression(&infix.rhs))?;
             self.iwrite("typ: ")?;
             self.write_type(&infix.typ, false)?;
             self.write("\n")
@@ -353,13 +353,13 @@ impl<O: Write> Printer<O> {
 
     fn print_postfix_call(&self, call: &PostfixCall) -> Result<()> {
         self.writeln("PostfixCall {")?;
-        self.indented(|_| {
+        self.indented(|| {
             self.writeln("target:")?;
-            self.indented(|_| self.print_expression(&call.target))?;
+            self.indented(|| self.print_expression(&call.target))?;
             self.iwrite("arguments: [")?;
             if !call.arguments.is_empty() {
                 self.write("\n")?;
-                self.indented(|_| {
+                self.indented(|| {
                     for argument in call.arguments.iter() {
                         self.print_expression(argument)?;
                     }
@@ -378,9 +378,9 @@ impl<O: Write> Printer<O> {
 
     fn print_postfix_property(&self, property: &PostfixProperty) -> Result<()> {
         self.writeln("PostfixCall {")?;
-        self.indented(|_| {
+        self.indented(|| {
             self.writeln("target:")?;
-            self.indented(|_| self.print_expression(&property.target))?;
+            self.indented(|| self.print_expression(&property.target))?;
             writeln!(self, "property: {}", property.property.name)?;
             self.iwrite("typ: ")?;
             self.write_type(&property.typ, true)?;

--- a/src/type_ast/translate.rs
+++ b/src/type_ast/translate.rs
@@ -67,14 +67,10 @@ fn translate_func(pfunc: &past::Func, scope: Scope) -> TypeResult<Func> {
     // TODO: This should be an `add_static` once functions are static.
     scope.add_local(&name, typ.clone())?;
 
-    let body = match &pfunc.body {
-        past::FuncBody::Block(block) => {
-            FuncBody::Block(translate_block(block, func_scope.clone())?)
-        }
-    };
+    let body = translate_block(&pfunc.body, func_scope.clone())?;
 
-    let implicit_retrn = body.typ();
-    unify(&retrn, &implicit_retrn, func_scope.clone())?;
+    let implicit_retrn = &body.typ;
+    unify(&retrn, implicit_retrn, func_scope.clone())?;
 
     Ok(Func {
         name: name.clone(),
@@ -407,7 +403,7 @@ mod tests {
         let pfunc = past::Func {
             name: word("foo"),
             arguments: vec![word("bar")],
-            body: past::FuncBody::Block(past::Block {
+            body: past::Block {
                 // statements: vec![past::BlockStatement::Expression(past::Expression::Infix(
                 //     past::Infix {
                 //         lhs: Box::new(past::Expression::Identifier(past::Identifier {
@@ -434,7 +430,7 @@ mod tests {
                     })),
                 ],
                 span: Span::unknown(),
-            }),
+            },
             span: Span::unknown(),
         };
 


### PR DESCRIPTION
- Sets up a top-level `StageError` type to hold errors occurring at different compilation stages (along with the file path and source of the originating location if applicable).
- Refactor representation of func bodies in parse and type ASTs to have blocks be the only possible node type for bodies.