### PR TITLE
Refactor scopes and add builtins

### DIFF
--- a/spec/e2e_ast/closure/out
+++ b/spec/e2e_ast/closure/out
@@ -37,7 +37,7 @@ Module {
   Func {
     name: main
     arguments: []
-    typ: main#8(): #13(
+    typ: main#8(): #16(
       Int,
     ): Int
     body:
@@ -58,7 +58,7 @@ Module {
               typ: Int
             }
           ]
-          typ: #13(
+          typ: #16(
             Int,
           ): Int
         }

--- a/src/compiler/ir/compile.rs
+++ b/src/compiler/ir/compile.rs
@@ -1,7 +1,6 @@
 use std::cell::{Cell, Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::rc::Rc;
-use std::sync::Arc;
 
 use super::super::super::frontend::Module as FrontendModule;
 use super::super::super::type_ast::{self as ast};

--- a/src/compiler/ir/frame.rs
+++ b/src/compiler/ir/frame.rs
@@ -1,0 +1,12 @@
+use super::super::super::type_ast::{self as ast, ScopeId};
+use super::{RealType, Value};
+
+pub trait Frame {
+    fn get_local(&self, name: &str) -> (usize, RealType);
+
+    /// Search for a static in the scope matching `scope_id`, which should be
+    /// either this frame or one if its parents.
+    ///
+    /// This MUST NOT return a `Value::Local`.
+    fn get_static(&self, name: &str, scope_id: ScopeId) -> Value;
+}

--- a/src/compiler/ir/mod.rs
+++ b/src/compiler/ir/mod.rs
@@ -2,15 +2,17 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::rc::{Rc, Weak};
 
-use super::super::type_ast::{self as ast};
+use super::super::type_ast::{self as ast, ScopeId};
 use super::vecs_equal::vecs_equal;
 
 mod compile;
 mod error;
+mod frame;
 mod typ;
 mod typer;
 mod value;
 
+use frame::Frame;
 use typ::*;
 use typer::Typer;
 
@@ -19,10 +21,12 @@ pub use error::IrError;
 pub use typ::RealType;
 pub use value::{AbstractValue, FuncId, FuncValue, LocalValue, StaticValue, Value, ValueId};
 
-/// A type which:
+/// Something which:
 ///   - Has a fully-qualified name.
 ///   - Can have funcs defined within it.
 ///   - Has a typer to resolve generics.
+///
+/// The current containers are `Module`s and `Func`s.
 trait Container {
     fn get_qualified_name(&self) -> String;
 
@@ -38,6 +42,7 @@ pub struct Root(Rc<InnerRoot>);
 struct InnerRoot {
     modules: RefCell<Vec<Module>>,
     typer: Typer,
+    statics: RefCell<HashMap<String, Value>>,
 }
 
 impl Root {
@@ -45,6 +50,7 @@ impl Root {
         Self(Rc::new(InnerRoot {
             modules: RefCell::new(vec![]),
             typer,
+            statics: RefCell::new(HashMap::new()),
         }))
     }
 
@@ -59,6 +65,7 @@ impl Root {
             qualified_name,
             parent: self.clone(),
             typer: Typer::new(ast_module.scope.id(), Some(self.0.typer.clone())),
+            scope_id: ast_module.scope.id(),
             funcs: RefCell::new(vec![]),
         }));
         let mut modules = self.0.modules.borrow_mut();
@@ -74,12 +81,39 @@ impl Root {
         self.0.modules.borrow().clone()
     }
 
+    fn set_static(&self, name: &str, value: Value) {
+        let mut statics = self.0.statics.borrow_mut();
+        statics.insert(name.to_string(), value);
+    }
+
     fn find_module_by_id(&self, id: usize) -> Option<Module> {
         let modules = self.0.modules.borrow();
         modules
             .iter()
             .find(|module| module.0.id == id)
             .map(|module| module.clone())
+    }
+}
+
+impl Frame for Root {
+    fn get_local(&self, name: &str) -> (usize, RealType) {
+        panic!("Cannot get_local on Root")
+    }
+
+    fn get_static(&self, name: &str, scope_id: ScopeId) -> Value {
+        if !scope_id.is_builtin() {
+            panic!(
+                "Exhausted frames searching for static: name: {}, scope_id: {:?}",
+                name, scope_id
+            )
+        }
+        let statics = self.0.statics.borrow();
+        for (static_name, value) in statics.iter() {
+            if static_name == name {
+                return value.clone();
+            }
+        }
+        panic!("Static not found: {}", name)
     }
 }
 
@@ -92,6 +126,9 @@ struct InnerModule {
     qualified_name: String,
     parent: Root,
     typer: Typer,
+    /// The scope ID for this module's root scope from the AST. We need this
+    /// to precisely look up statics from `ScopeResolution`s.
+    scope_id: ScopeId,
     funcs: RefCell<Vec<Func>>,
 }
 
@@ -126,6 +163,29 @@ impl Container for Module {
     }
 }
 
+impl Frame for Module {
+    fn get_local(&self, name: &str) -> (usize, RealType) {
+        panic!("Cannot get_local on Module")
+    }
+
+    fn get_static(&self, name: &str, scope_id: ScopeId) -> Value {
+        if self.0.scope_id == scope_id {
+            // Current only funcs are supported as statics.
+            let funcs = self.0.funcs.borrow();
+            for func in funcs.iter() {
+                if func.name() == name {
+                    return Value::Abstract(AbstractValue::UnspecializedFunc(func.clone()));
+                }
+            }
+            panic!("Static not found in Module: {}", name)
+        } else {
+            self.0.parent.get_static(name, scope_id)
+        }
+    }
+}
+
+impl FuncParent for Module {}
+
 /// AbstractType::UnspecializedFunc -> Func -> FuncValue
 #[derive(Clone)]
 pub struct Func(Rc<InnerFunc>);
@@ -139,17 +199,19 @@ impl Func {
     }
 }
 
+trait FuncParent: Container + Frame {}
+
 struct InnerFunc {
     /// The parent that this func is declared in; should be one of:
     ///   - `Module` for root-level funcs.
     ///   - `FuncValue` for a func nested within another func.
-    parent: Box<dyn Container>,
+    parent: Box<dyn FuncParent>,
     specializations: RefCell<Vec<FuncValue>>,
     ast_func: ast::Func,
 }
 
 impl Func {
-    fn new(ast_func: ast::Func, parent: Box<dyn Container>) -> Self {
+    fn new(ast_func: ast::Func, parent: Box<dyn FuncParent>) -> Self {
         Self(Rc::new(InnerFunc {
             parent,
             specializations: RefCell::new(vec![]),
@@ -202,8 +264,12 @@ impl Func {
         &self.0.ast_func.name
     }
 
-    fn get_parent_typer(&self) -> Typer {
-        self.0.parent.get_typer()
+    fn scope_id(&self) -> ScopeId {
+        self.0.ast_func.scope.id()
+    }
+
+    fn get_parent(&self) -> &Box<dyn FuncParent> {
+        &self.0.parent
     }
 
     pub fn borrow_specializations(&self) -> Ref<Vec<FuncValue>> {

--- a/src/compiler/ir/mod.rs
+++ b/src/compiler/ir/mod.rs
@@ -17,7 +17,7 @@ use typer::Typer;
 pub use compile::{compile_modules, Instruction};
 pub use error::IrError;
 pub use typ::RealType;
-pub use value::{FuncId, FuncValue, LocalValue, StaticValue, Value, ValueId};
+pub use value::{AbstractValue, FuncId, FuncValue, LocalValue, StaticValue, Value, ValueId};
 
 /// A type which:
 ///   - Has a fully-qualified name.
@@ -48,12 +48,17 @@ impl Root {
         }))
     }
 
-    fn add_module(&self, id: usize, qualified_name: String) -> Module {
+    fn add_module(
+        &self,
+        id: usize,
+        qualified_name: String,
+        ast_module: Ref<ast::Module>,
+    ) -> Module {
         let module = Module(Rc::new(InnerModule {
             id,
             qualified_name,
             parent: self.clone(),
-            typer: Typer::new(Some(self.0.typer.clone())),
+            typer: Typer::new(ast_module.scope.id(), Some(self.0.typer.clone())),
             funcs: RefCell::new(vec![]),
         }));
         let mut modules = self.0.modules.borrow_mut();

--- a/src/compiler/ir/value.rs
+++ b/src/compiler/ir/value.rs
@@ -64,6 +64,7 @@ impl Value {
                 AbstractValue::UnspecializedFunc(func) => {
                     Type::Abstract(AbstractType::UnspecializedFunc(func.clone()))
                 }
+                AbstractValue::SpecializableBuiltinFunc(_, retrn) => Type::Real(retrn.clone()),
             },
         }
     }
@@ -105,6 +106,9 @@ pub enum StaticValue {
 #[derive(Clone)]
 pub enum AbstractValue {
     UnspecializedFunc(Func),
+    /// A builtin func that can be dynamically specialized when generating
+    /// target code.
+    SpecializableBuiltinFunc(String, RealType),
 }
 
 #[derive(Clone, Eq, Hash, PartialEq)]
@@ -152,9 +156,8 @@ impl FuncValue {
         parameters: Vec<RealType>,
         retrn: RealType,
     ) -> Self {
-        let typer = Typer::new(Some(func.get_parent_typer()));
-
         let ast_func = &func.0.ast_func;
+        let typer = Typer::new(ast_func.scope.id(), Some(func.get_parent_typer()));
 
         // Store the mappings of AST parameter and retrn types to the
         // corresponding real types in this specialization.

--- a/src/compiler/opaque.rs
+++ b/src/compiler/opaque.rs
@@ -29,6 +29,10 @@ macro_rules! opaque {
                 pub fn open<'a, 'ctx>(&'a self) -> &'a $typ<'ctx> {
                     unsafe { transmute::<&[<$typ Size>], &$typ<'ctx>>(&self.0) }
                 }
+
+                pub fn take<'ctx>(self) -> $typ<'ctx> {
+                    unsafe { transmute::<[<$typ Size>], $typ<'ctx>>(self.0) }
+                }
             }
 
             impl Debug for [<Opaque $typ>] {

--- a/src/compiler/target/builtins.ll
+++ b/src/compiler/target/builtins.ll
@@ -1,0 +1,9 @@
+declare i32 @printf(i8* nocapture, ...) nounwind
+
+@builtin_println_int64_fmt = private unnamed_addr constant [4 x i8] c"%d\0A\00"
+
+define external i64 @builtin_println_int64(i64 %value) {
+    %deref = getelementptr [4 x i8], [4 x i8]* @builtin_println_int64_fmt, i32 0, i32 0
+    call i32 (i8*, ...) @printf(i8* %deref, i64 %value)
+    ret i64 0
+}

--- a/src/compiler/target/builtins.rs
+++ b/src/compiler/target/builtins.rs
@@ -1,8 +1,8 @@
-use inkwell::values::{BasicValueEnum, FunctionValue, PointerValue};
-use inkwell::module::{Module, Linkage};
+use inkwell::builder::Builder;
 use inkwell::context::Context;
 use inkwell::memory_buffer::MemoryBuffer;
-use inkwell::builder::Builder;
+use inkwell::module::{Linkage, Module};
+use inkwell::values::{BasicValueEnum, FunctionValue, PointerValue};
 
 use super::super::opaque::OpaqueModule;
 
@@ -11,9 +11,10 @@ pub fn initialize(ctx: &Context) -> Module {
     let memory_buffer = MemoryBuffer::create_from_memory_range_copy(data_ir, "builtins");
     match ctx.create_module_from_ir(memory_buffer) {
         Ok(module) => module,
-        Err(string) => {
-            panic!("Error initializing builtins module from LLVM IR:\n{}", string.to_string())
-        }
+        Err(string) => panic!(
+            "Error initializing builtins module from LLVM IR:\n{}",
+            string.to_string()
+        ),
     }
 }
 

--- a/src/compiler/target/builtins.rs
+++ b/src/compiler/target/builtins.rs
@@ -1,0 +1,68 @@
+use inkwell::values::{BasicValueEnum, FunctionValue, PointerValue};
+use inkwell::module::{Module, Linkage};
+use inkwell::context::Context;
+use inkwell::memory_buffer::MemoryBuffer;
+use inkwell::builder::Builder;
+
+use super::super::opaque::OpaqueModule;
+
+pub fn initialize(ctx: &Context) -> Module {
+    let data_ir = include_bytes!("builtins.ll");
+    let memory_buffer = MemoryBuffer::create_from_memory_range_copy(data_ir, "builtins");
+    match ctx.create_module_from_ir(memory_buffer) {
+        Ok(module) => module,
+        Err(string) => {
+            panic!("Error initializing builtins module from LLVM IR:\n{}", string.to_string())
+        }
+    }
+}
+
+pub fn get_builtin_func<'ctx>(
+    module: &Module<'ctx>,
+    name: &str,
+    arguments: &Vec<BasicValueEnum>,
+) -> FunctionValue<'ctx> {
+    // Uncomment to see the layout of the module we've loaded:
+    //   module.print_to_stderr();
+    let function_name = match name {
+        "println" => get_println_specialization(arguments),
+        _ => unreachable!("Invalid builtin func name: {}", name),
+    };
+    module.get_function(function_name).unwrap()
+}
+
+pub fn get_println_specialization(arguments: &Vec<BasicValueEnum>) -> &'static str {
+    if arguments.len() != 1 {
+        unreachable!("println accepts 1 argument, got {}", arguments.len())
+    }
+    let argument = &arguments[0];
+    match argument {
+        BasicValueEnum::IntValue(_) => "builtin_println_int64",
+        _ => {
+            let typ = argument.get_type();
+            unreachable!("println cannot be called with: {:?}", typ)
+        }
+    }
+}
+
+// The following implementation will work if we DON'T link the builtins module
+// into the main module at the beginning of compilation; not doing so implies
+// we will link in the builtins object file when building the binary:
+//
+//   pub fn get_builtin_func<'ctx>(
+//       module: &Module<'ctx>,
+//       builtins_module: &Module<'ctx>,
+//       name: &str,
+//   ) -> FunctionValue<'ctx> {
+//       if let Some(already_defined) = module.get_function(name) {
+//           return already_defined
+//       }
+//       // Uncomment to see the layout of the module we've loaded:
+//       //   builtins_module.print_to_stderr();
+//       let builtin_name = match name {
+//           "println" => "builtin_println_int64",
+//           _ => unreachable!("Invalid builtin func name: {}", name),
+//       };
+//       let typ = builtins_module.get_function(builtin_name).unwrap().get_type();
+//       module.add_function(builtin_name, typ, Some(Linkage::AvailableExternally))
+//   }

--- a/src/compiler/target/mod.rs
+++ b/src/compiler/target/mod.rs
@@ -1,9 +1,9 @@
 use std::cell::{Ref, RefCell};
 use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::io::{self, Write};
-use std::ffi::{OsString, OsStr};
 
 use inkwell::context::Context;
 use inkwell::module::Module as InkModule;
@@ -198,12 +198,10 @@ pub fn compile_modules(modules: &Vec<Module>) {
                             .iter()
                             .map(|ir_argument| value_resolver.get(ir_argument))
                             .collect::<Vec<_>>();
-                        let function_value = builtins::get_builtin_func(
-                            &module,
-                            builtin_func_name,
-                            &arguments
-                        );
-                        let call_site = builder.build_call(function_value, arguments.as_slice(), "println");
+                        let function_value =
+                            builtins::get_builtin_func(&module, builtin_func_name, &arguments);
+                        let call_site =
+                            builder.build_call(function_value, arguments.as_slice(), "println");
                         let retrn = call_site.try_as_basic_value().left().unwrap();
                         value_resolver.set(ir_retrn, retrn);
                     }
@@ -292,7 +290,10 @@ fn generate_module(module: InkModule) {
         .unwrap();
 
     if !output.status.success() {
-        println!("Failed to invoke to Clang (exited with {:?})", output.status.code());
+        println!(
+            "Failed to invoke to Clang (exited with {:?})",
+            output.status.code()
+        );
         io::stdout().write_all(&output.stdout).unwrap();
         io::stderr().write_all(&output.stderr).unwrap();
     }

--- a/src/type_ast/builtins.rs
+++ b/src/type_ast/builtins.rs
@@ -1,37 +1,79 @@
+use std::cell::RefCell;
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::rc::Rc;
 
-use super::typ::{next_uid, Class, IntrinsicClass};
+use super::scope::{FuncScope, Scope, ScopeLike};
+use super::typ::{next_uid, Class, Func, Generic, IntrinsicClass, Type};
 
-pub struct Builtins(Arc<HashMap<String, Class>>);
+pub struct Builtins(BuiltinsInner);
+
+struct BuiltinsInner {
+    classes: HashMap<String, Class>,
+    funcs: HashMap<String, Rc<Func>>,
+}
+
+fn new_generic(scope: Scope) -> Type {
+    Type::Generic(Rc::new(RefCell::new(Generic::new(scope))))
+}
 
 lazy_static! {
     static ref BUILTINS: Builtins = {
-        let mut builtins = HashMap::new();
-
-        let mut instrinsic = |name: &str| {
+        let mut classes = HashMap::new();
+        let mut add_class = |name: &str| {
             let class = IntrinsicClass {
                 id: next_uid(),
                 name: name.to_string(),
             };
-            builtins.insert(name.to_string(), Class::Intrinsic(Arc::new(class)));
+            classes.insert(name.to_string(), Class::Intrinsic(Rc::new(class)));
         };
-        instrinsic("Int");
 
-        Builtins(Arc::new(builtins))
+        add_class("Int");
+
+        let mut funcs = HashMap::new();
+        let mut add_func = |name: &str, arguments: Vec<Type>, retrn: Type, scope: Scope| {
+            let func = Func {
+                id: next_uid(),
+                scope,
+                name: Some(name.to_string()),
+                arguments: RefCell::new(arguments),
+                retrn: RefCell::new(retrn),
+            };
+            funcs.insert(name.to_string(), Rc::new(func));
+        };
+
+        let scope = FuncScope::new(None).into_scope();
+        add_func(
+            "println",
+            vec![new_generic(scope.clone())],
+            Type::new_unit(scope.clone()),
+            scope,
+        );
+
+        Builtins(BuiltinsInner { classes, funcs })
     };
 }
 
 impl Builtins {
-    pub fn get<S: AsRef<str>>(name: S) -> Class {
-        let builtins = &BUILTINS.0;
-        builtins
+    pub fn get_class<S: AsRef<str>>(name: S) -> Class {
+        let classes = &BUILTINS.0.classes;
+        classes
             .get(name.as_ref())
             .expect(&format!("Builtin not found: {}", name.as_ref()))
             .clone()
     }
 
-    pub fn get_all() -> &'static HashMap<String, Class> {
-        &BUILTINS.0
+    // NOTE: Only supports funcs right now.
+    pub fn try_get<S: AsRef<str>>(name: S) -> Option<Type> {
+        let funcs = &BUILTINS.0.funcs;
+        funcs.get(name.as_ref()).map(|typ| Type::Func(typ.clone()))
+    }
+
+    pub fn get_all_classes() -> &'static HashMap<String, Class> {
+        &BUILTINS.0.classes
     }
 }
+
+// Not actually safe to share between threads, but we're not currently
+// multi-threaded so it's okay.
+unsafe impl Send for Builtins {}
+unsafe impl Sync for Builtins {}

--- a/src/type_ast/mod.rs
+++ b/src/type_ast/mod.rs
@@ -42,6 +42,12 @@ pub enum TypeError {
     LocalNotFound {
         name: String,
     },
+    StaticAlreadyDefined {
+        name: String,
+    },
+    CannotAddStatic {
+        message: String,
+    },
     CannotCapture {
         name: String,
     },
@@ -95,6 +101,8 @@ impl TypeError {
         let message = match self.unwrap() {
             LocalAlreadyDefined { .. } => "LocalAlreadyDefined",
             LocalNotFound { .. } => "LocalNotFound",
+            StaticAlreadyDefined { .. } => "StaticAlreadyDefined",
+            CannotAddStatic { .. } => "CannotAddStatic",
             CannotCapture { .. } => "CannotCapture",
             // PropertyAlreadyDefined { .. } => "PropertyAlreadyDefined",
             CannotUnify { .. } => "CannotUnify",

--- a/src/type_ast/mod.rs
+++ b/src/type_ast/mod.rs
@@ -24,7 +24,7 @@ mod unify;
 pub use builtins::Builtins;
 pub use nodes::*;
 pub use printer::{Printer, PrinterOptions};
-pub use scope::{ClosureScope, ModuleScope, Scope, ScopeLike, ScopeResolution};
+pub use scope::{ClosureScope, ModuleScope, Scope, ScopeId, ScopeLike, ScopeResolution};
 pub use translate::translate_module;
 pub use typ::{
     Class, Func as TFunc, Generic, GenericConstraint, IntrinsicClass, PropertyConstraint, Type,

--- a/src/type_ast/mod.rs
+++ b/src/type_ast/mod.rs
@@ -9,7 +9,6 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
 
 use super::parser::{Span, Token, Word};
 use super::{parse_ast as past, StageError};

--- a/src/type_ast/translate.rs
+++ b/src/type_ast/translate.rs
@@ -100,7 +100,7 @@ fn translate_block(pblock: &past::Block, scope: Scope) -> TypeResult<Block> {
         statements.push(statement);
     }
     let typ = if statements.is_empty() {
-        Type::new_empty_tuple(scope)
+        Type::new_unit(scope)
     } else {
         statements.last().unwrap().typ()
     };
@@ -160,7 +160,7 @@ fn translate_expression(pexpression: &past::Expression, scope: Scope) -> TypeRes
             })
         }
         past::Expression::LiteralInt(pliteral) => {
-            let class = Builtins::get("Int");
+            let class = Builtins::get_class("Int");
             Expression::LiteralInt(LiteralInt {
                 value: pliteral.value,
                 typ: Type::new_object(class, scope),
@@ -369,7 +369,10 @@ mod tests {
         translate_expression(&pexpression, scope.clone()).map(|_| ())?;
         assert_eq!(
             foo,
-            Type::new_substitute(Type::new_object(Builtins::get("Int"), scope.clone()), scope)
+            Type::new_substitute(
+                Type::new_object(Builtins::get_class("Int"), scope.clone()),
+                scope
+            )
         );
 
         Ok(())

--- a/src/type_ast/typ.rs
+++ b/src/type_ast/typ.rs
@@ -1,7 +1,6 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
 
 use super::scope::Scope;
 use super::{Closable, RecursionTracker, TypeError, TypeResult};
@@ -90,7 +89,7 @@ impl Type {
         Type::Variable(Rc::new(RefCell::new(variable)))
     }
 
-    pub fn new_empty_tuple(scope: Scope) -> Self {
+    pub fn new_unit(scope: Scope) -> Self {
         Type::Tuple(Tuple {
             id: next_uid(),
             scope,
@@ -627,8 +626,8 @@ impl PartialEq for Object {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Class {
-    Intrinsic(Arc<IntrinsicClass>),
-    Derived(Arc<DerivedClass>),
+    Intrinsic(Rc<IntrinsicClass>),
+    Derived(Rc<DerivedClass>),
 }
 
 impl Class {


### PR DESCRIPTION
- Refactors scopes in the AST and IR to better handle resolution of statics.
- Adds hacky implementation of a `println` builtin function (to be fixed).